### PR TITLE
fix: dont sanitize trusted content

### DIFF
--- a/src/Frontend/ContentContainer.php
+++ b/src/Frontend/ContentContainer.php
@@ -85,9 +85,9 @@ class ContentContainer {
 
 		$html  = '<sesamy-article item-src="' . esc_url( $item_src ) . '" publisher-content-id="' . esc_attr( (string) $post->ID ) . '">';
 		$html .= '<sesamy-content-container lock-mode="' . esc_attr( $lock_mode ) . '">';
-		$html .= '<div slot="preview">' . wp_kses_post( $preview ) . '</div>';
+		$html .= '<div slot="preview">' . $preview . '</div>';
 		if ( 'embed' === $lock_mode ) {
-			$html .= '<div slot="content">' . wp_kses_post( $content ) . '</div>';
+			$html .= '<div slot="content">' . $content . '</div>';
 		} elseif ( 'encode' === $lock_mode ) {
 			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 			$html .= '<div slot="content" style="display:none;">' . base64_encode( $content ) . '</div>';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserves original HTML formatting in content previews and embedded content, preventing unintended stripping of tags.
  * Ensures more accurate rendering across both embed and encode modes.
  * Improves consistency between preview and final content display, reducing discrepancies users previously observed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->