### PR TITLE
fix: print general sesamy-meta-tags on all pages

### DIFF
--- a/src/Frontend/Meta.php
+++ b/src/Frontend/Meta.php
@@ -54,41 +54,39 @@ class Meta {
 	 * @return void
 	 */
 	public function add_meta_tags() {
+		global $post;
+		$options = get_option( 'sesamy_settings' );
+
+		if ( ! empty( $options['client_id'] ) ) {
+			echo '<meta name="sesamy:client-id" content="' . esc_attr( $options['client_id'] ) . '">';
+		}
+		if ( ! empty( $options['default_pass'] ) ) {
+			echo '<meta name="sesamy:pass" content="' . esc_attr( $options['default_pass'] ) . '">';
+		}
+
+		$currency = $options['default_currency'] ?? '';
+		if ( ! empty( $currency ) ) {
+			echo '<meta name="sesamy:currency" content="' . esc_attr( $currency ) . '">';
+		}
+
 		if ( is_singular() ) {
-			global $post;
-			$enabled_post_types = get_enabled_post_types();
-			if ( in_array( $post->post_type, $enabled_post_types, true ) ) {
-				$options = get_option( 'sesamy_settings' );
-				if ( ! empty( $options['client_id'] ) ) {
-					echo '<meta name="sesamy:client-id" content="' . esc_attr( $options['client_id'] ) . '">';
-				}
-				if ( ! empty( $options['default_pass'] ) ) {
-					echo '<meta name="sesamy:pass" content="' . esc_attr( $options['default_pass'] ) . '">';
-				}
+			$is_locked    = (bool) ( get_post_meta( $post->ID, '_sesamy_locked', true ) ?? false );
+			$access_level = $is_locked ? get_post_meta( $post->ID, '_sesamy_access_level', true ) : 'public';
+			echo '<meta name="sesamy:accessLevel" content="' . esc_attr( $access_level ) . '">';
 
-				$is_locked    = (bool) ( get_post_meta( $post->ID, '_sesamy_locked', true ) ?? false );
-				$access_level = $is_locked ? get_post_meta( $post->ID, '_sesamy_access_level', true ) : 'public';
-				echo '<meta name="sesamy:accessLevel" content="' . esc_attr( $access_level ) . '">';
-
-				$currency = $options['default_currency'] ?? '';
-				if ( ! empty( $currency ) ) {
-					echo '<meta name="sesamy:currency" content="' . esc_attr( $currency ) . '">';
+			$single_purchase = (bool) ( get_post_meta( $post->ID, '_sesamy_enable_single_purchase', true ) ?? false );
+			if ( $single_purchase ) {
+				$default_price = $options['default_price'] ?? '';
+				$meta_price    = get_post_meta( $post->ID, '_sesamy_price', true );
+				$price         = ! empty( $meta_price ) ? $meta_price : $default_price;
+				if ( ! empty( $price ) ) {
+					echo '<meta name="sesamy:price" content="' . esc_attr( $price ) . '">';
 				}
+			}
 
-				$single_purchase = (bool) ( get_post_meta( $post->ID, '_sesamy_enable_single_purchase', true ) ?? false );
-				if ( $single_purchase ) {
-					$default_price = $options['default_price'] ?? '';
-					$meta_price    = get_post_meta( $post->ID, '_sesamy_price', true );
-					$price         = ! empty( $meta_price ) ? $meta_price : $default_price;
-					if ( ! empty( $price ) ) {
-						echo '<meta name="sesamy:price" content="' . esc_attr( $price ) . '">';
-					}
-				}
-
-				$locked_content_redirect_url = get_post_meta( $post->ID, '_sesamy_locked_content_redirect_url', true );
-				if ( ! empty( $locked_content_redirect_url ) ) {
-					echo '<meta name="sesamy:locked-content-redirect-url" content="' . esc_attr( $locked_content_redirect_url ) . '">';
-				}
+			$locked_content_redirect_url = get_post_meta( $post->ID, '_sesamy_locked_content_redirect_url', true );
+			if ( ! empty( $locked_content_redirect_url ) ) {
+				echo '<meta name="sesamy:locked-content-redirect-url" content="' . esc_attr( $locked_content_redirect_url ) . '">';
 			}
 		}
 	}

--- a/src/Frontend/Meta.php
+++ b/src/Frontend/Meta.php
@@ -72,7 +72,9 @@ class Meta {
 		if ( is_singular() ) {
 			$is_locked    = (bool) ( get_post_meta( $post->ID, '_sesamy_locked', true ) ?? false );
 			$access_level = $is_locked ? get_post_meta( $post->ID, '_sesamy_access_level', true ) : 'public';
-			echo '<meta name="sesamy:accessLevel" content="' . esc_attr( $access_level ) . '">';
+			if ( ! empty( $access_level ) ) {
+				echo '<meta name="sesamy:accessLevel" content="' . esc_attr( $access_level ) . '">';
+			}
 
 			$single_purchase = (bool) ( get_post_meta( $post->ID, '_sesamy_enable_single_purchase', true ) ?? false );
 			if ( $single_purchase ) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a meta tag to support redirecting users when content is locked.

* **Bug Fixes**
  * Ensures key meta tags (client ID, default pass, currency) are consistently present across pages.
  * Emits access level metadata only when applicable, improving accuracy for locked vs. public content.
  * Shows price metadata only when single-purchase is enabled, using post-specific value or a sensible default.
  * Improves reliability of metadata for pricing and access, reducing inconsistent behavior across different post contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->