### PR TITLE
feat: add Sesamy Login block, shortcode, and classic menu item

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Connect your WordPress site to [Sesamy.com](https://sesamy.com) to sell and mana
   - [Advanced: API token](#advanced-api-token)
 - [Publisher registration](#publisher-registration)
 - [Per-post controls](#per-post-controls)
+- [Rendering Sesamy Login](#rendering-sesamy-login)
 - [Frontend behavior](#frontend-behavior)
 - [Local development](#local-development)
 - [Linting and tests](#linting-and-tests)
@@ -228,6 +229,33 @@ Enabled post types get an extra **Sesamy** column showing 🔒 Locked and 💰 S
 
 ---
 
+## Rendering Sesamy Login
+
+The plugin exposes the Sesamy Login `<sesamy-login>` web component through three insertion surfaces so editors can drop a sign-in button anywhere it's needed. All three are gated on a valid plugin connection — they render nothing while disconnected.
+
+### Block (`sesamy/login`)
+
+Available in the inserter (under Widgets) and inside any Navigation block. The block has an optional **Button text** attribute that becomes a `<span slot="button-text">…</span>` inside the component; leave it empty to use the web component's default label.
+
+Inside a Navigation block the rendered output is wrapped in `<li>` so it sits alongside other nav items; elsewhere it renders inside a plain `<div>`.
+
+### Shortcode (`[sesamy-login]`)
+
+For the Classic Editor, text widgets, and any context that runs shortcodes:
+
+```text
+[sesamy-login]
+[sesamy-login button_text="Sign in"]
+```
+
+The optional `button_text` attribute behaves the same as the block's Button text.
+
+### Classic menu item
+
+For sites still using **Appearance → Menus**, a "Sesamy" meta box in the left column lets editors add a "Sesamy Login" item to any menu like a built-in item. Tick the option, click **Add to Menu**, and save — the rendered menu item is swapped for `<sesamy-login>` on the frontend, using the menu item's title as the button label.
+
+---
+
 ## Frontend behavior
 
 When the plugin is connected and a post type is enabled, every singular page of that post type:
@@ -333,7 +361,7 @@ src/
   Core/Assets.php          # Enqueues the Sesamy frontend bundle
   Frontend/ContentContainer.php # Wraps `the_content` per lock mode
   Frontend/Meta.php        # `<head>` meta tags
-  Frontend/Login.php       # Login state hooks
+  Frontend/Login.php       # `sesamy/login` block, `[sesamy-login]` shortcode, classic-menus meta box
   Proxy/Router.php         # `/sesamy/api/*` and `/sesamy/auth/*` proxy
   Support/helpers.php      # Settings defaults, URL builder, helpers
 assets/

--- a/assets/js/login-block.js
+++ b/assets/js/login-block.js
@@ -1,0 +1,71 @@
+import { registerBlockType } from '@wordpress/blocks';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, TextControl } from '@wordpress/components';
+import { addFilter } from '@wordpress/hooks';
+import { __ } from '@wordpress/i18n';
+
+// core/navigation declares its allowedBlocks in block.json, which is baked
+// into the editor's JS bundle. Extending it server-side has no effect on
+// the editor — we have to filter the block settings client-side. The editor
+// calls reapplyBlockTypeFilters() before registerCoreBlocks(), so this
+// applies regardless of script load order.
+addFilter('blocks.registerBlockType', 'sesamy/login/extend-navigation', (settings, name) => {
+	if (name !== 'core/navigation') {
+		return settings;
+	}
+	return {
+		...settings,
+		allowedBlocks: [...(settings.allowedBlocks ?? []), 'sesamy/login'],
+	};
+});
+
+const Edit = ({ attributes, setAttributes }) => {
+	const blockProps = useBlockProps({ className: 'sesamy-login-block' });
+	const { buttonText } = attributes;
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={__('Login button', 'sesamy')}>
+					<TextControl
+						__nextHasNoMarginBottom
+						label={__('Button label', 'sesamy')}
+						value={buttonText || ''}
+						onChange={(value) => setAttributes({ buttonText: value })}
+						help={__('Leave empty to use the default label.', 'sesamy')}
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div {...blockProps}>
+				<span className="sesamy-login-block__placeholder">
+					{buttonText ? `[sesamy-login "${buttonText}"]` : '[sesamy-login]'}
+				</span>
+			</div>
+		</>
+	);
+};
+
+registerBlockType('sesamy/login', {
+	apiVersion: 3,
+	title: __('Sesamy Login', 'sesamy'),
+	description: __(
+		'Adds the Sesamy login button. Place it inside a Navigation block or anywhere else on the page.',
+		'sesamy',
+	),
+	category: 'widgets',
+	icon: 'lock',
+	attributes: {
+		buttonText: {
+			type: 'string',
+			role: 'content',
+		},
+	},
+	supports: {
+		html: false,
+		className: true,
+		// Marks this as a "content block" so the editor allows inserting it
+		// into Navigation when the menu is locked to contentOnly editing.
+		contentRole: true,
+	},
+	edit: Edit,
+	save: () => null,
+});

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "devURL": "http://127.0.0.1:8888",
     "entry": {
       "admin": "./assets/js/admin.js",
+      "login-block": "./assets/js/login-block.js",
       "post-settings": "./assets/js/post-settings.js",
       "sesamy": "./assets/js/sesamy.js"
     }

--- a/src/Frontend/Login.php
+++ b/src/Frontend/Login.php
@@ -12,7 +12,7 @@ use function SesamyPlugin\Helpers\is_config_valid;
 /**
  * Login module.
  *
- * Registers the `sesamy/login` block.
+ * Registers the `sesamy/login` block and the `[sesamy-login]` shortcode.
  *
  * @package Sesamy2
  */
@@ -36,6 +36,7 @@ class Login {
 	public function register() {
 		if ( is_config_valid() ) {
 			add_action( 'init', [ $this, 'register_block' ] );
+			add_shortcode( 'sesamy-login', [ $this, 'render_shortcode' ] );
 		}
 	}
 
@@ -106,5 +107,33 @@ class Login {
 
 		$wrapper_attributes = get_block_wrapper_attributes();
 		return sprintf( '<div %s><sesamy-login>%s</sesamy-login></div>', $wrapper_attributes, $slot );
+	}
+
+	/**
+	 * Render callback for the `[sesamy-login]` shortcode.
+	 *
+	 * Emits the <sesamy-login> web component. Accepts an optional
+	 * `button_text` attribute to override the default button label.
+	 *
+	 * @param array|string $atts Shortcode attributes.
+	 * @return string
+	 */
+	public function render_shortcode( $atts ) {
+		if ( ! is_config_valid() ) {
+			return '';
+		}
+
+		$atts = shortcode_atts(
+			[ 'button_text' => '' ],
+			is_array( $atts ) ? $atts : [],
+			'sesamy-login'
+		);
+
+		$button_text = trim( (string) $atts['button_text'] );
+		$slot        = '' !== $button_text
+			? sprintf( '<span slot="button-text">%s</span>', esc_html( $button_text ) )
+			: '';
+
+		return sprintf( '<sesamy-login>%s</sesamy-login>', $slot );
 	}
 }

--- a/src/Frontend/Login.php
+++ b/src/Frontend/Login.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Login module.
+ *
+ * @package Sesamy2
+ */
+
+namespace SesamyPlugin\Frontend;
+
+use function SesamyPlugin\Helpers\is_config_valid;
+
+/**
+ * Login module.
+ *
+ * Registers the `sesamy/login` block.
+ *
+ * @package Sesamy2
+ */
+class Login {
+	/**
+	 * Initialize the module.
+	 *
+	 * @return self
+	 */
+	public static function init() {
+		$instance = new self();
+		$instance->register();
+		return $instance;
+	}
+
+	/**
+	 * Register any hooks and filters.
+	 *
+	 * @return void
+	 */
+	public function register() {
+		if ( is_config_valid() ) {
+			add_action( 'init', [ $this, 'register_block' ] );
+		}
+	}
+
+	/**
+	 * Register the Sesamy Login block.
+	 *
+	 * @return void
+	 */
+	public function register_block() {
+		$asset_file = SESAMY_PLUGIN_DIST_PATH . 'js/login-block.asset.php';
+		$asset      = is_readable( $asset_file ) ? require $asset_file : [
+			'dependencies' => [],
+			'version'      => SESAMY_PLUGIN_VERSION,
+		];
+
+		wp_register_script(
+			'sesamy-login-block',
+			SESAMY_PLUGIN_URL . 'dist/js/login-block.js',
+			$asset['dependencies'],
+			$asset['version'],
+			true
+		);
+
+		register_block_type(
+			'sesamy/login',
+			[
+				'api_version'     => 3,
+				'editor_script'   => 'sesamy-login-block',
+				// `showSubmenuIcon` is provided by core/navigation, so its
+				// presence in $block->context tells us we're being rendered
+				// inside one. We don't use the value — just the presence.
+				'uses_context'    => [ 'showSubmenuIcon' ],
+				'render_callback' => [ $this, 'render_login_block' ],
+			]
+		);
+	}
+
+	/**
+	 * Server-side render callback for the sesamy/login block.
+	 *
+	 * Emits the <sesamy-login> web component. When placed inside a Navigation
+	 * block we wrap it in an <li> so it sits alongside the other nav items;
+	 * elsewhere we render a plain wrapper.
+	 *
+	 * @param array     $attributes Block attributes.
+	 * @param string    $content    Inner block content (unused).
+	 * @param \WP_Block $block      Block instance.
+	 * @return string
+	 */
+	public function render_login_block( $attributes, $content, $block ) {
+		if ( ! is_config_valid() ) {
+			return '';
+		}
+
+		$in_navigation = is_array( $block->context ) && array_key_exists( 'showSubmenuIcon', $block->context );
+
+		$button_text = isset( $attributes['buttonText'] ) ? trim( (string) $attributes['buttonText'] ) : '';
+		$slot        = '' !== $button_text
+			? sprintf( '<span slot="button-text">%s</span>', esc_html( $button_text ) )
+			: '';
+
+		if ( $in_navigation ) {
+			$wrapper_attributes = get_block_wrapper_attributes(
+				[ 'class' => 'wp-block-navigation-item sesamy-login-menu-item' ]
+			);
+			return sprintf( '<li %s><sesamy-login>%s</sesamy-login></li>', $wrapper_attributes, $slot );
+		}
+
+		$wrapper_attributes = get_block_wrapper_attributes();
+		return sprintf( '<div %s><sesamy-login>%s</sesamy-login></div>', $wrapper_attributes, $slot );
+	}
+}

--- a/src/Frontend/Login.php
+++ b/src/Frontend/Login.php
@@ -62,7 +62,7 @@ class Login {
 		register_block_type(
 			'sesamy/login',
 			[
-				'api_version'     => 3,
+				'api_version'     => '3',
 				'editor_script'   => 'sesamy-login-block',
 				// `showSubmenuIcon` is provided by core/navigation, so its
 				// presence in $block->context tells us we're being rendered

--- a/src/Frontend/Login.php
+++ b/src/Frontend/Login.php
@@ -12,7 +12,8 @@ use function SesamyPlugin\Helpers\is_config_valid;
 /**
  * Login module.
  *
- * Registers the `sesamy/login` block and the `[sesamy-login]` shortcode.
+ * Registers the `sesamy/login` block, the `[sesamy-login]` shortcode, and a
+ * classic-menus meta box for adding the login as a menu item.
  *
  * @package Sesamy2
  */
@@ -36,6 +37,8 @@ class Login {
 	public function register() {
 		if ( is_config_valid() ) {
 			add_action( 'init', [ $this, 'register_block' ] );
+			add_action( 'load-nav-menus.php', [ $this, 'register_menu_meta_box' ] );
+			add_filter( 'walker_nav_menu_start_el', [ $this, 'filter_classic_menu_item' ], 10, 2 );
 			add_shortcode( 'sesamy-login', [ $this, 'render_shortcode' ] );
 		}
 	}
@@ -107,6 +110,120 @@ class Login {
 
 		$wrapper_attributes = get_block_wrapper_attributes();
 		return sprintf( '<div %s><sesamy-login>%s</sesamy-login></div>', $wrapper_attributes, $slot );
+	}
+
+	/**
+	 * Register the "Sesamy" meta box on the classic-menus admin screen.
+	 *
+	 * Adds a left-column picker on Appearance → Menus so users on classic
+	 * menus can drop a Sesamy Login item into a menu like any other item.
+	 *
+	 * @return void
+	 */
+	public function register_menu_meta_box() {
+		add_meta_box(
+			'sesamy-login-menu-item',
+			__( 'Sesamy', 'sesamy2' ),
+			[ $this, 'render_menu_meta_box' ],
+			'nav-menus',
+			'side',
+			'default'
+		);
+	}
+
+	/**
+	 * Render the contents of the classic-menus meta box.
+	 *
+	 * Form field names follow the conventions WordPress uses for the
+	 * built-in Pages/Posts/Custom Links pickers so the standard
+	 * "Add to Menu" handler picks up our item with no extra wiring.
+	 * The item is stored as a custom-link menu item carrying a
+	 * `sesamy-login-menu-item` CSS class — that class is the marker
+	 * `filter_classic_menu_item()` looks for on render.
+	 *
+	 * @return void
+	 */
+	public function render_menu_meta_box() {
+		$label         = __( 'Sesamy Login', 'sesamy2' );
+		$error_message = __( 'Please select an option.', 'sesamy2' );
+		?>
+		<div id="sesamy-login-menu-item-meta-box" class="posttypediv">
+			<div class="tabs-panel tabs-panel-active">
+				<ul class="categorychecklist form-no-clear">
+					<li>
+						<label class="menu-item-title">
+							<input type="checkbox" class="menu-item-checkbox" name="menu-item[-1][menu-item-object-id]" value="-1" />
+							<?php echo esc_html( $label ); ?>
+						</label>
+						<input type="hidden" class="menu-item-type" name="menu-item[-1][menu-item-type]" value="custom" />
+						<input type="hidden" class="menu-item-title" name="menu-item[-1][menu-item-title]" value="<?php echo esc_attr( $label ); ?>" />
+						<input type="hidden" class="menu-item-url" name="menu-item[-1][menu-item-url]" value="#sesamy-login" />
+						<input type="hidden" name="menu-item[-1][menu-item-classes]" value="sesamy-login-menu-item" />
+					</li>
+				</ul>
+			</div>
+			<p class="button-controls wp-clearfix">
+				<span class="add-to-menu">
+					<input type="submit" class="button submit-add-to-menu right" value="<?php esc_attr_e( 'Add to Menu', 'sesamy2' ); ?>" name="add-sesamy-login-menu-item" id="submit-sesamy-login-menu-item-meta-box" />
+					<span class="spinner"></span>
+				</span>
+			</p>
+		</div>
+		<script>
+		( function( $ ) {
+			$( function() {
+				var $box     = $( '#sesamy-login-menu-item-meta-box' );
+				var $submit  = $( '#submit-sesamy-login-menu-item-meta-box' );
+				var message  = <?php echo wp_json_encode( $error_message ); ?>;
+				$submit.on( 'click', function( e ) {
+					if ( $box.find( '.menu-item-checkbox' ).is( ':checked' ) ) {
+						$box.find( '.sesamy-login-error' ).remove();
+						return;
+					}
+					e.preventDefault();
+					e.stopImmediatePropagation();
+					if ( ! $box.find( '.sesamy-login-error' ).length ) {
+						$( '<p class="sesamy-login-error notice notice-error notice-alt" tabindex="-1" role="alert"></p>' )
+							.text( message )
+							.insertBefore( $submit.closest( 'p' ) )
+							.trigger( 'focus' );
+					}
+				} );
+			} );
+		} )( jQuery );
+		</script>
+		<?php
+	}
+
+	/**
+	 * Swap a classic-menu Sesamy Login item for the <sesamy-login> component.
+	 *
+	 * The item is identified by the `sesamy-login-menu-item` CSS class set
+	 * by the meta box (or the sentinel URL, as a fallback). The menu item
+	 * title becomes the button label slot so users can rename it from the
+	 * standard menu admin without extra UI.
+	 *
+	 * @param string   $item_output Default item output.
+	 * @param \WP_Post $item        Current menu item.
+	 * @return string
+	 */
+	public function filter_classic_menu_item( $item_output, $item ) {
+		if ( ! is_object( $item ) ) {
+			return $item_output;
+		}
+
+		$classes = isset( $item->classes ) && is_array( $item->classes ) ? $item->classes : [];
+		$url     = isset( $item->url ) ? (string) $item->url : '';
+		if ( ! in_array( 'sesamy-login-menu-item', $classes, true ) && '#sesamy-login' !== $url ) {
+			return $item_output;
+		}
+
+		$title = isset( $item->title ) ? trim( (string) $item->title ) : '';
+		$slot  = '' !== $title
+			? sprintf( '<span slot="button-text">%s</span>', esc_html( $title ) )
+			: '';
+
+		return sprintf( '<sesamy-login>%s</sesamy-login>', $slot );
 	}
 
 	/**

--- a/src/PluginCore.php
+++ b/src/PluginCore.php
@@ -44,6 +44,7 @@ class PluginCore {
 		\SesamyPlugin\Connect\ConnectFlow::init();
 		\SesamyPlugin\Core\Assets::init();
 		\SesamyPlugin\Frontend\ContentContainer::init();
+		\SesamyPlugin\Frontend\Login::init();
 		\SesamyPlugin\Frontend\Meta::init();
 		\SesamyPlugin\Proxy\Router::init();
 	}


### PR DESCRIPTION
## Summary
- Adds a `Login` module that exposes the Sesamy Login `<sesamy-login>` web component through three insertion surfaces, all gated on `is_config_valid()`:
  - **Block** (`sesamy/login`) — server-rendered; when placed inside a Navigation block the output is wrapped in `<li>` so it sits alongside other nav items, otherwise in a `<div>`. Supports an optional `buttonText` attribute rendered as a `<span slot="button-text">` inside the component.
  - **Shortcode** (`[sesamy-login]`) — same component for classic editor, text widgets, and any context that runs shortcodes; supports an optional `button_text` attribute.
  - **Classic menus meta box** — a new "Sesamy" meta box on Appearance → Menus lets users add a Sesamy Login item to a classic menu like any built-in item. The item is stored as a custom-link `nav_menu_item` carrying the `sesamy-login-menu-item` class (with `#sesamy-login` as a fallback marker); `walker_nav_menu_start_el` swaps the rendered `<a>` for `<sesamy-login>`, using the menu item's title as the button-text slot. Inline jQuery shows "Please select an option." when the "Add to Menu" button is clicked without ticking the checkbox.
- Adds the editor-side JS (`assets/js/login-block.js`) that registers the block and extends `core/navigation`'s `allowedBlocks` client-side so the block can be inserted into Navigation.

## Test plan
- [x] Block — appears in the inserter under Widgets and inside a Navigation block; renders `<sesamy-login>` on the frontend in both placements; `buttonText` attribute renders as the button-text slot.
- [x] Shortcode — `[sesamy-login]` renders `<sesamy-login>` on the frontend; `[sesamy-login button_text="Sign in"]` adds the button-text slot.
- [x] Classic menus — "Sesamy" meta box appears on Appearance → Menus; ticking "Sesamy Login" and clicking "Add to Menu" adds the item; clicking with the checkbox unticked shows the inline error notice; the saved menu renders `<sesamy-login>` on the frontend with the menu item's title as the button text.
- [x] Nothing renders (block, shortcode, or menu item swap) when the plugin config is invalid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)