### PR TITLE
fix: keep frontend paywalls working for legacy-config upgraders

### DIFF
--- a/src/Admin/View/ConnectionNotice.php
+++ b/src/Admin/View/ConnectionNotice.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * Connection Notice module.
+ *
+ * @package Sesamy2
+ */
+
+namespace SesamyPlugin\Admin\View;
+
+use function SesamyPlugin\Helpers\get_sesamy_connection;
+use function SesamyPlugin\Helpers\is_sesamy_connected;
+
+/**
+ * Surfaces an admin banner when the plugin is installed but no real
+ * `sesamy_connection` exists. Two variants:
+ *
+ *  - Fresh install (no `sesamy_connection`, no legacy `sesamy_settings.client_id`):
+ *    informational "Connect to Sesamy" prompt, dismissible per-user.
+ *  - Legacy upgrade (no real `sesamy_connection`, but `get_sesamy_connection()`
+ *    returns a `legacy_upgrade` stub): "Reconnect required" — un-dismissible
+ *    because the frontend still renders paywalls, so it's easy to miss that
+ *    server-side capabilities (Capsule, publisher registration, management
+ *    API) are degraded until the publisher runs Connect.
+ *
+ * Scoped to Dashboard, Plugins, and the Sesamy settings page to keep the
+ * banner visible where the operator is most likely to act on it without
+ * leaking onto unrelated screens.
+ *
+ * @package Sesamy2
+ */
+class ConnectionNotice {
+
+	/**
+	 * Per-user meta key recording dismissal of the fresh-install variant.
+	 * Stored as `'1'` once dismissed; absence means "still show". The legacy
+	 * variant is intentionally not dismissible and ignores this key.
+	 */
+	private const DISMISSED_META = 'sesamy_connect_notice_dismissed';
+
+	/**
+	 * Initialize the module.
+	 *
+	 * @return self
+	 */
+	public static function init() {
+		$instance = new self();
+		$instance->register();
+		return $instance;
+	}
+
+	/**
+	 * Register any hooks and filters.
+	 *
+	 * @return void
+	 */
+	public function register() {
+		add_action( 'admin_notices', [ $this, 'render_notice' ] );
+		add_action( 'wp_ajax_sesamy_dismiss_connect_notice', [ $this, 'handle_dismiss' ] );
+	}
+
+	/**
+	 * Render the appropriate notice for the current admin screen + connection
+	 * state, or nothing if neither applies.
+	 *
+	 * @return void
+	 */
+	public function render_notice() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		$screen = get_current_screen();
+		if ( ! $screen ) {
+			return;
+		}
+		// Limit visibility to screens where the operator is most likely to
+		// notice and act: WP home (Dashboard), where they manage plugins
+		// (Plugins), and the Sesamy page itself. Avoids nagging across every
+		// post edit / media / settings screen.
+		$allowed_screens = [ 'dashboard', 'plugins', 'toplevel_page_sesamy' ];
+		if ( ! in_array( $screen->id, $allowed_screens, true ) ) {
+			return;
+		}
+
+		// Real connection — nothing to nag about.
+		if ( is_sesamy_connected() ) {
+			return;
+		}
+
+		// `get_sesamy_connection()` returns a non-null array for the legacy
+		// stub (synthesized from `sesamy_settings.client_id`). Null means the
+		// install has no Sesamy state at all — a fresh install.
+		$is_legacy   = is_array( get_sesamy_connection() );
+		$connect_url = admin_url( 'admin.php?page=sesamy' );
+
+		if ( $is_legacy ) {
+			$this->render_legacy_notice( $connect_url );
+			return;
+		}
+
+		$this->render_fresh_notice( $connect_url );
+	}
+
+	/**
+	 * Render the legacy-upgrade variant. Not dismissible: the frontend looks
+	 * fine, so a dismiss button would invite the publisher to ignore the
+	 * degraded server-side state indefinitely.
+	 *
+	 * @param string $connect_url Settings page URL.
+	 * @return void
+	 */
+	private function render_legacy_notice( $connect_url ) {
+		?>
+		<div class="notice notice-error">
+			<p>
+				<strong><?php esc_html_e( 'Sesamy: reconnect required.', 'sesamy2' ); ?></strong>
+				<?php esc_html_e( 'Your existing paywalls still render, but Capsule unlock, publisher registration, and the management API need a fresh connection after upgrading.', 'sesamy2' ); ?>
+				<a href="<?php echo esc_url( $connect_url ); ?>" class="button button-primary" style="margin-left: 0.5em;"><?php esc_html_e( 'Reconnect to Sesamy', 'sesamy2' ); ?></a>
+			</p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Render the fresh-install variant. Per-user dismissible; once dismissed,
+	 * suppressed for that user until the meta is cleared (no plugin code
+	 * clears it — by design, a user who dismisses owns that decision).
+	 *
+	 * @param string $connect_url Settings page URL.
+	 * @return void
+	 */
+	private function render_fresh_notice( $connect_url ) {
+		$user_id = get_current_user_id();
+		if ( get_user_meta( $user_id, self::DISMISSED_META, true ) ) {
+			return;
+		}
+
+		$nonce = wp_create_nonce( 'sesamy_dismiss_connect_notice' );
+		?>
+		<div class="notice notice-info is-dismissible" data-sesamy-dismiss-nonce="<?php echo esc_attr( $nonce ); ?>">
+			<p>
+				<strong><?php esc_html_e( 'Welcome to Sesamy.', 'sesamy2' ); ?></strong>
+				<?php esc_html_e( 'Connect this site to your Sesamy account to start gating content with paywalls.', 'sesamy2' ); ?>
+				<a href="<?php echo esc_url( $connect_url ); ?>" class="button button-primary" style="margin-left: 0.5em;"><?php esc_html_e( 'Connect to Sesamy', 'sesamy2' ); ?></a>
+			</p>
+			<script>
+				// WP core (`wp-admin/js/common.js`) injects the `.notice-dismiss`
+				// button asynchronously after this markup parses, so we can't
+				// attach to it directly here. Delegate from the notice instead
+				// so the listener exists before core wires the button up.
+				( function () {
+					var notice = document.currentScript.parentElement;
+					notice.addEventListener( 'click', function ( event ) {
+						if ( ! event.target.classList.contains( 'notice-dismiss' ) ) {
+							return;
+						}
+						var body = new FormData();
+						body.append( 'action', 'sesamy_dismiss_connect_notice' );
+						body.append( '_wpnonce', notice.dataset.sesamyDismissNonce );
+						fetch( window.ajaxurl, { method: 'POST', credentials: 'same-origin', body: body } );
+					} );
+				} )();
+			</script>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Persist the per-user dismissal. Fired by the inline dismiss script in
+	 * the fresh-install variant only.
+	 *
+	 * @return void
+	 */
+	public function handle_dismiss() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( null, 403 );
+		}
+		check_ajax_referer( 'sesamy_dismiss_connect_notice' );
+		update_user_meta( get_current_user_id(), self::DISMISSED_META, '1' );
+		wp_send_json_success();
+	}
+}

--- a/src/PluginCore.php
+++ b/src/PluginCore.php
@@ -36,6 +36,7 @@ class PluginCore {
 		// Init class interfaces
 		\SesamyPlugin\Admin\Settings\Core::init();
 		\SesamyPlugin\Admin\Settings\Post::init();
+		\SesamyPlugin\Admin\View\ConnectionNotice::init();
 		\SesamyPlugin\Admin\View\ReleaseNotice::init();
 		\SesamyPlugin\Admin\View\SettingsPage::init();
 		\SesamyPlugin\Api\Rest::init();

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -89,18 +89,21 @@ function get_enabled_post_types() {
  *
  * Synthesizes a stub bundle from legacy `sesamy_settings.client_id` when no
  * `sesamy_connection` option exists. Pre-rewrite installs stored the publisher
- * identifier under `sesamy_settings.client_id` and used it both as the
- * connection marker and as the script-host segment — so the same value seeds
- * both `client_id` (to satisfy `is_sesamy_connected()`) and `tenant` (to feed
- * the frontend bootstrap's `clientId` / bundle URL). Keeps locked articles
- * rendering paywalls across the upgrade without a destructive DB write, so
- * downgrades remain safe and the stub is replaced wholesale once the publisher
- * runs Connect.
+ * identifier under `sesamy_settings.client_id` and used it as the script-host
+ * segment — so the same value seeds both `client_id` (read by
+ * `get_sesamy_client_id()` to keep `is_config_valid()` true) and `tenant`
+ * (read by `get_sesamy_vendor_id()` to feed the frontend bootstrap's
+ * `clientId` / bundle URL). Keeps locked articles rendering paywalls across
+ * the upgrade without a destructive DB write, so downgrades remain safe and
+ * the stub is replaced wholesale once the publisher runs Connect.
  *
- * `integration_type = 'legacy_upgrade'` marks the stub so other modules can
- * recognise it — notably, disconnect-revoke is a no-op for legacy stubs since
- * we never had a `registration_client_uri` / `registration_access_token` to
- * call back to AuthHero with.
+ * `integration_type = 'legacy_upgrade'` marks the stub so callers can
+ * distinguish it from a real connection. `is_sesamy_connected()` keys off
+ * this to return false on legacy installs — the settings page then shows
+ * "Connect to Sesamy" and skips the publisher-registration panel (which
+ * needs M2M credentials the stub doesn't have). Disconnect-revoke is also a
+ * no-op for legacy stubs since `registration_client_uri` /
+ * `registration_access_token` are absent.
  *
  * @return array<string, mixed>|null
  */
@@ -147,10 +150,21 @@ function get_sesamy_vendor_id() {
 /**
  * Whether the site has completed the Sesamy connect flow.
  *
+ * Legacy stubs synthesised by `get_sesamy_connection()` deliberately fail
+ * this check — they lack the M2M credentials needed for server-side calls
+ * (publisher registration, capsule, management API), so treating them as
+ * "connected" on the settings page produces a misleading status alongside
+ * the API errors those modules raise. Returning false here surfaces the
+ * Connect button instead and hides the publisher-registration panel.
+ *
  * @return bool
  */
 function is_sesamy_connected() {
-	return get_sesamy_client_id() !== null;
+	$connection = get_sesamy_connection();
+	if ( ! is_array( $connection ) || empty( $connection['client_id'] ) ) {
+		return false;
+	}
+	return 'legacy_upgrade' !== ( $connection['integration_type'] ?? '' );
 }
 
 /**
@@ -264,11 +278,15 @@ function sesamy_url( $path, $type = 'api', $direct = false ) {
 /**
  * Is config valid?
  *
- * Checks both that the publisher has connected via the Stage 0 flow and that
- * the legacy content-gating settings are populated.
+ * Frontend gate — true whenever we have *any* form of publisher identifier
+ * (real connection or legacy stub) and the gating settings are populated.
+ * Deliberately broader than `is_sesamy_connected()`: a legacy upgrader has no
+ * M2M credentials but still has the vendor id needed to load the script
+ * bundle and render paywalls. The strict check belongs to the settings page,
+ * not the reader-facing render path.
  *
  * @return bool
  */
 function is_config_valid() {
-	return is_sesamy_connected() && ! empty( get_sesamy_setting( 'default_paywall' ) ) && ! empty( get_sesamy_setting( 'enabled_content_types' ) ) && ! empty( get_sesamy_setting( 'lock_mode' ) );
+	return null !== get_sesamy_client_id() && ! empty( get_sesamy_setting( 'default_paywall' ) ) && ! empty( get_sesamy_setting( 'enabled_content_types' ) ) && ! empty( get_sesamy_setting( 'lock_mode' ) );
 }

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -87,11 +87,38 @@ function get_enabled_post_types() {
 /**
  * Get the stored Sesamy connection bundle written at the end of the connect flow.
  *
+ * Synthesizes a stub bundle from legacy `sesamy_settings.client_id` when no
+ * `sesamy_connection` option exists. Pre-rewrite installs stored the publisher
+ * identifier under `sesamy_settings.client_id` and used it both as the
+ * connection marker and as the script-host segment — so the same value seeds
+ * both `client_id` (to satisfy `is_sesamy_connected()`) and `tenant` (to feed
+ * the frontend bootstrap's `clientId` / bundle URL). Keeps locked articles
+ * rendering paywalls across the upgrade without a destructive DB write, so
+ * downgrades remain safe and the stub is replaced wholesale once the publisher
+ * runs Connect.
+ *
+ * `integration_type = 'legacy_upgrade'` marks the stub so other modules can
+ * recognise it — notably, disconnect-revoke is a no-op for legacy stubs since
+ * we never had a `registration_client_uri` / `registration_access_token` to
+ * call back to AuthHero with.
+ *
  * @return array<string, mixed>|null
  */
 function get_sesamy_connection() {
 	$connection = get_option( 'sesamy_connection' );
-	return is_array( $connection ) ? $connection : null;
+	if ( is_array( $connection ) ) {
+		return $connection;
+	}
+	$legacy = get_option( 'sesamy_settings' );
+	if ( is_array( $legacy ) && ! empty( $legacy['client_id'] ) ) {
+		return [
+			'client_id'        => (string) $legacy['client_id'],
+			'tenant'           => (string) $legacy['client_id'],
+			'environment'      => ! empty( $legacy['development_mode'] ) ? 'dev' : 'prod',
+			'integration_type' => 'legacy_upgrade',
+		];
+	}
+	return null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Stage-2 moved the publisher identifier from `sesamy_settings.client_id` to a new `sesamy_connection` option written by ConnectFlow. Without a fallback, sites upgrading from main land in the disconnected state — paywalls stop rendering, and a fresh install has no on-ramp from anywhere except the Sesamy settings page itself. This PR adds three layers so the upgrade is invisible on the reader-facing side, clean on the settings page, and discoverable from common admin screens.

### 1. Lazy `sesamy_connection` stub for legacy upgraders

`get_sesamy_connection()` synthesizes an in-memory bundle from `sesamy_settings.client_id` when no real `sesamy_connection` exists. The legacy value seeds both `client_id` (for `get_sesamy_client_id()`) and `tenant` (for the frontend bootstrap's `clientId` / bundle URL), since pre-rewrite the same value was used both ways. Tagged `integration_type = 'legacy_upgrade'` so callers can tell it apart from a real connection. No DB write — downgrade stays safe and the stub is replaced wholesale once the publisher runs Connect.

### 2. Split connected-state semantics

`is_sesamy_connected()` now rejects legacy stubs so the settings page surfaces the **Connect to Sesamy** button instead of a contradictory "Status: Connected" sitting next to "Sesamy is not connected" errors from `list_publishers` and friends. `is_config_valid()` switches to a direct `get_sesamy_client_id()` check so the frontend gate stays broad enough to render paywalls for legacy installs.

### 3. Connection-required admin banner (`ConnectionNotice`)

New module at `src/Admin/View/ConnectionNotice.php`, scoped to **Dashboard, Plugins, and the Sesamy settings page**. Two variants:

- **Fresh install** (`notice-info`, dismissible): "Welcome to Sesamy. Connect this site to your Sesamy account to start gating content with paywalls."
- **Legacy upgrade** (`notice-error`, **not** dismissible): "Sesamy: reconnect required. Your existing paywalls still render, but Capsule unlock, publisher registration, and the management API need a fresh connection after upgrading."

The legacy variant is deliberately un-dismissible because the frontend still works — without a forcing function, it's easy to ignore that server-side capabilities are degraded. Fresh-install dismissal is per-user via `sesamy_connect_notice_dismissed` user meta, written by a `wp_ajax_sesamy_dismiss_connect_notice` handler triggered from the notice's inline JS (event-delegated from the notice div, since WP core injects `.notice-dismiss` asynchronously).

## Test plan

### Legacy upgrade path
- [ ] Build on `main`, fire up `wp-env`, configure a `sesamy_settings.client_id`, save a locked post.
- [ ] Check out this branch, rebuild, reload the WP env (same DB).
- [ ] Frontend: locked article still renders the Sesamy paywall, bundle still loads from `scripts.sesamy.{com,dev}/s/<id>/bundle`.
- [ ] Admin → Sesamy: Connection panel shows **Connect to Sesamy** (no "Connected" status, no publisher-registration panel, no "Sesamy is not connected" notices).
- [ ] Dashboard, Plugins, and Sesamy screens show the red **"Sesamy: reconnect required"** banner with no dismiss button.
- [ ] Run Connect → real `sesamy_connection` is written, banner disappears, publisher-registration panel returns.

### Fresh install path
- [ ] Fresh wp-env with no `sesamy_settings` / `sesamy_connection` options.
- [ ] Dashboard, Plugins, and Sesamy screens show the blue **"Welcome to Sesamy"** banner with a dismiss (X) button.
- [ ] Dismiss → banner disappears for the current user, stays gone across reloads.
- [ ] Verify a different admin user still sees the banner (per-user dismissal).
- [ ] Banner does NOT show on unrelated screens (post edit, media, settings → general, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Legacy banner:
<img width="1259" height="71" alt="image" src="https://github.com/user-attachments/assets/13e82c2a-084c-43e9-9614-a22ac24faa6a" />

Fresh install banner:
<img width="834" height="67" alt="image" src="https://github.com/user-attachments/assets/35744291-e6b8-4bd4-abfe-b9bf20bce144" />
