### PR TITLE
fix: skip git hooks when committing built assets in the release workflow

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -61,7 +61,9 @@ jobs:
           yarn build
           git checkout --detach
           git add -f dist
-          git commit -m "build: bundle assets for ${TAG}"
+          # --no-verify: husky's pre-commit hook needs vendor/bin (composer
+          # deps), which is never installed in this workflow.
+          git commit --no-verify -m "build: bundle assets for ${TAG}"
           git tag -f -a "${TAG}" -m "${TAG}"
           git checkout main
 


### PR DESCRIPTION
The "Version bump & publish" workflow has failed on the last two pushes to main: the bundle-assets `git commit` triggers husky's pre-commit hook, which runs `./vendor/bin/phpcs` — never installed in CI — so the run dies before the release tag is pushed (run 28799960396).

The `npm run release` commit already survives because `commit-and-tag-version` is invoked with `--no-verify`; this applies the same to the assets commit.

Merging this will trigger the workflow and should produce the first tag that Packagist can consume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release asset build workflow so release-tag commits complete reliably in environments without local verification tools installed.
  * The release commit message and push/tag flow remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->