### PR TITLE
fix: disable husky entirely in the release workflow

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -15,6 +15,10 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      # Disable husky hooks (pre-commit/pre-push run phpcs and phpstan);
+      # composer dependencies are never installed in this workflow.
+      HUSKY: "0"
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:


### PR DESCRIPTION
Run 28938634544 got further than before — bump and asset build succeeded — but the push step failed on husky's **pre-push** hook (`composer static` → `phpstan: not found`), since composer dependencies are never installed in this workflow.

Instead of adding `--no-verify` hook-by-hook, this sets `HUSKY: "0"` at the job level, husky's documented kill switch, so no git hook runs in the release job. Linting/static analysis still run on developer machines and in CI checks as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release workflow to avoid running local Git hooks during automated releases, helping release jobs complete more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->