### PR TITLE
chore: upgrade firebase/php-jwt to ^7.0 (fixes CVE-2025-45769)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   "require": {
     "php": ">=8.3",
     "composer/installers": "^2.0",
-    "firebase/php-jwt": "^6.4",
+    "firebase/php-jwt": "^7.0",
     "sesamy/capsule-publisher": "^1.0"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f1ec942e4e42e201fb4974aecfcf7809",
+    "content-hash": "f1adb381a67ef80a0bece3775d922b6e",
     "packages": [
         {
             "name": "composer/installers",
@@ -154,16 +154,16 @@
         },
         {
             "name": "firebase/php-jwt",
-            "version": "v6.11.1",
+            "version": "v7.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/php-jwt.git",
-                "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66"
+                "reference": "b374a5d1a4f1f67fadc2165cdb284645945e2fc0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/php-jwt/zipball/d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
-                "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
+                "url": "https://api.github.com/repos/googleapis/php-jwt/zipball/b374a5d1a4f1f67fadc2165cdb284645945e2fc0",
+                "reference": "b374a5d1a4f1f67fadc2165cdb284645945e2fc0",
                 "shasum": ""
             },
             "require": {
@@ -171,6 +171,8 @@
             },
             "require-dev": {
                 "guzzlehttp/guzzle": "^7.4",
+                "phpfastcache/phpfastcache": "^9.2",
+                "phpseclib/phpseclib": "~3.0",
                 "phpspec/prophecy-phpunit": "^2.0",
                 "phpunit/phpunit": "^9.5",
                 "psr/cache": "^2.0||^3.0",
@@ -179,7 +181,8 @@
             },
             "suggest": {
                 "ext-sodium": "Support EdDSA (Ed25519) signatures",
-                "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present"
+                "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present",
+                "phpseclib/phpseclib": "Support PS256 (RSASSA-PSS) signatures"
             },
             "type": "library",
             "autoload": {
@@ -204,16 +207,16 @@
                 }
             ],
             "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
-            "homepage": "https://github.com/firebase/php-jwt",
+            "homepage": "https://github.com/googleapis/php-jwt",
             "keywords": [
                 "jwt",
                 "php"
             ],
             "support": {
                 "issues": "https://github.com/googleapis/php-jwt/issues",
-                "source": "https://github.com/googleapis/php-jwt/tree/v6.11.1"
+                "source": "https://github.com/googleapis/php-jwt/tree/v7.1.0"
             },
-            "time": "2025-04-09T20:32:01+00:00"
+            "time": "2026-06-11T17:54:14+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",


### PR DESCRIPTION
## What

Bumps `firebase/php-jwt` from `^6.4` (locked v6.11.1) to `^7.0` (locked v7.1.0).

## Why

The whole 6.x line is affected by [CVE-2025-45769](https://github.com/advisories/GHSA-2x45-7fc3-mxwq) (weak encryption / undersized-key acceptance), fixed only in 7.0.0. `composer audit` drops from 2 advisories to 1 (the remaining one is the unrelated transitive phpseclib SSRF).

## Compatibility

- **Single call site** — [`src/Api/Rest.php`](src/Api/Rest.php) does `JWT::decode($token, JWK::parseKeySet($jwks))`. Both APIs keep the same signatures in 7.x; no code change needed.
- **The one breaking change in 7.0** is a minimum RSA key length of **2048 bits** at decode time (the CVE fix; check is `< 2048`). We verify Sesamy RS256 tokens against the `auth2.sesamy.{com,dev}` JWKS, whose keys are all **2048- or 4096-bit**, so verification is unaffected.
- **PHP**: 7.x requires PHP ≥8.0; this plugin requires ≥8.3.

## Validation

- `composer update` resolves cleanly — single package update, no dependency conflicts (`sesamy/capsule-publisher` doesn't constrain php-jwt).
- PHPStan: clean.
- Existing test suite: unchanged (the 8 pre-existing `WP_Mock` failures in `UrlHelperTest` are identical on 6.11.1 and don't touch php-jwt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a security/authentication-related dependency to a newer major version, keeping the project current and compatible with recent improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->