### PR TITLE
docs: document Composer/Packagist installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,27 @@ Access decisions (who can read which article) live in **paywall strategies on Se
 
 ## Installation
 
-### Production install
+### Production install (zip upload)
 
 1. Download the latest `.zip` from the [Releases page](https://github.com/sesamyab/wordpress-sesamy-2/releases).
 2. In WordPress admin, go to **Plugins → Add New → Upload Plugin** and upload the `.zip`.
 3. Activate the plugin. A new top-level **Sesamy** menu appears in the admin sidebar.
 4. Open **Sesamy** and follow [Connecting to Sesamy](#connecting-to-sesamy).
+
+### Composer install
+
+For Composer-managed sites (Bedrock and similar), the plugin is published on
+[Packagist](https://packagist.org/packages/sesamy/sesamy-wordpress):
+
+```bash
+composer require sesamy/sesamy-wordpress
+```
+
+It is typed as a `wordpress-plugin`, so [composer/installers](https://github.com/composer/installers)
+places it under your plugins directory (e.g. `wp-content/plugins/sesamy-wordpress`).
+Released tags ship with the built frontend assets bundled, so there's no
+`yarn build` step — activate the plugin and continue with
+[Connecting to Sesamy](#connecting-to-sesamy).
 
 ### Local development install
 


### PR DESCRIPTION
The README's Installation section covered only zip upload and local dev. Now that the plugin is published on Packagist as `sesamy/sesamy-wordpress`, this adds a **Composer install** subsection:

```bash
composer require sesamy/sesamy-wordpress
```

It notes that `composer/installers` places it under the plugins directory and that released tags bundle the built frontend assets (no `yarn build` needed). The existing "Production install" heading is clarified to "Production install (zip upload)"; the table of contents links to `#installation` only, so no TOC change was required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the installation guide with clearer “Production install (zip upload)” steps, including an additional menu-opening step after activation.
  * Added a new “Composer install” section explaining how to install via Composer and where the plugin will be placed.
  * Clarified that released packages include bundled frontend assets, so no build step is needed before activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->