### PR TITLE
feat: lock articles automatically by category or tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Connect your WordPress site to [Sesamy.com](https://sesamy.com) to sell and mana
   - [General: Content Types](#general-content-types)
   - [General: Default Paywall](#general-default-paywall)
   - [General: Default Pass](#general-default-pass)
+  - [General: Automatic locking](#general-automatic-locking)
   - [Advanced: Lock Mode](#advanced-lock-mode)
   - [Advanced: First-party proxy](#advanced-first-party-proxy)
   - [Advanced: API token](#advanced-api-token)
@@ -37,7 +38,7 @@ Connect your WordPress site to [Sesamy.com](https://sesamy.com) to sell and mana
 Once connected, the plugin:
 
 1. Adds a **Sesamy** menu in WP admin where you connect the site, pick the default paywall and pass, and decide which post types are gateable.
-2. Adds **per-post controls** (Block Editor sidebar, Classic Editor meta box, Quick Edit, and Bulk Edit) to lock individual posts and override defaults.
+2. Adds **per-post controls** (Block Editor sidebar, Classic Editor meta box, Quick Edit, and Bulk Edit) to lock individual posts and override defaults, plus **automatic locking** by category or tag for whole content sections.
 3. Emits Sesamy meta tags in `<head>` — vendor id, default pass, currency, per-post access level, price, and any locked-content redirect — so the Sesamy frontend bundle can identify the publisher and the article.
 4. Wraps the post content in a Sesamy container at render time so the bundle can apply the paywall, swap in unlocked content for entitled readers, or redirect to an alternative URL.
 5. Optionally proxies Sesamy auth and API traffic through your own domain (`/sesamy/api/*`, `/sesamy/auth/*`) for first-party cookies and ad-blocker resilience.
@@ -143,6 +144,28 @@ If the management API call fails, an error message is shown inline and the exist
 
 The Sesamy pass (entitlement bundle) that's announced to the frontend bundle via the `sesamy:pass` meta tag. Used by the Sesamy reader UI to tell users what subscription unlocks the content. Like `default_paywall`, the dropdown is populated live from the management API and previously-saved-but-deleted SKUs are preserved as "(not found)".
 
+### General: Automatic locking
+
+- **Setting key:** `locked_terms`
+- **Type:** Checkbox list of taxonomy terms, grouped per taxonomy
+- **Default:** None
+
+Locks every article carrying any of the selected terms — categories, tags, or terms of any public, REST-exposed custom taxonomy registered on the enabled content types. This is the recommended path when migrating from rule-based membership plugins (MemberPress, Paid Memberships Pro, Restrict Content Pro): recreate the old "protect category X" rule as one term selection and the entire archive is locked retroactively, without editing any posts.
+
+How it combines with the per-post toggle:
+
+- **Additive (OR)** — an article is locked when its per-post toggle is on *or* it has a selected term. A term rule can lock, never unlock.
+- **Non-destructive** — the rule is evaluated at render time and never writes the `_sesamy_locked` post meta. Remove the term (or deselect it here) and each post falls back to whatever its own toggle says.
+- **Consistent everywhere** — the same effective state drives frontend rendering (all lock modes, including Capsule encryption), the `<head>` meta tags, the REST endpoint, and the admin UI.
+
+In the editor, a term-locked post shows its lock toggle checked and disabled with a note naming the term ("Locked automatically by category 'Premium'"); the per-post fields (single purchase, custom paywall URL, redirect) remain editable. The post list column distinguishes the source: `🔒 Locked` for the per-post toggle vs `🔒 Locked (Category: Premium)` for term rules.
+
+Notes:
+
+- Because Bulk Edit only writes the per-post meta, setting "Not Locked" in bulk does not unlock term-locked posts — the column will keep showing the term as the lock source.
+- On sites with full-page caching, flush the cache after changing this setting; it affects every article with the selected terms.
+- Developers can hook the `sesamy_is_post_locked` filter (`bool $locked, int $post_id`) to add bespoke lock rules (by author, legacy plugin meta, etc.); filter-driven locks display as `Locked (filter)` in the post list.
+
 ### Advanced: Lock Mode
 
 - **Setting key:** `lock_mode`
@@ -208,7 +231,7 @@ Fields:
 
 | Field | Meta key | Notes |
 |---|---|---|
-| Lock this article | `_sesamy_locked` | When off, post is fully public and the lock-mode setting is ignored. |
+| Lock this article | `_sesamy_locked` | When off (and no [Automatic locking](#general-automatic-locking) term matches), the post is fully public and the lock-mode setting is ignored. Shown checked + disabled when a term rule locks the post. |
 | Enable single purchase | `_sesamy_enable_single_purchase` | Shows the Price field and emits a `sesamy:price` meta. Only meaningful when Locked. |
 | Price | `_sesamy_price` | Per-post override of `default_price`. Currency comes from the global `default_currency`. |
 | Custom Paywall URL | `_sesamy_custom_paywall_url` | Per-post override of `default_paywall`. Accepts a full URL or a paywall id. |
@@ -225,7 +248,7 @@ The Bulk Edit panel exposes the same two fields as `— No Change — / Locked /
 
 ### Post list column
 
-Enabled post types get an extra **Sesamy** column showing 🔒 Locked and 💰 Single Purchase pills based on the meta values above.
+Enabled post types get an extra **Sesamy** column showing 🔒 Locked and 💰 Single Purchase pills based on the meta values above. Posts locked by an [Automatic locking](#general-automatic-locking) rule show the source instead: `🔒 Locked (Category: Premium)`.
 
 ---
 

--- a/assets/js/post-settings.js
+++ b/assets/js/post-settings.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
 import { ToggleControl, PanelRow, TextControl } from '@wordpress/components';
 
@@ -20,6 +20,38 @@ const SesamySettingsPanel = () => {
 	const meta = useSelect((select) => select('core/editor').getEditedPostAttribute('meta'));
 	const { editPost } = useDispatch('core/editor');
 
+	// First "Automatic locking" rule matching the edited post's terms, or null.
+	// Reads the *edited* term selection so the lock state updates live as the
+	// editor assigns or removes a locking category/tag, before saving.
+	const lockingRule = useSelect((select) => {
+		const rules = select('core').getEntityRecord('root', 'site')?.sesamy_settings?.locked_terms;
+		if (!rules?.length) {
+			return null;
+		}
+		const taxonomies = select('core').getTaxonomies({ per_page: -1 });
+		return (
+			rules.find((rule) => {
+				const restBase = taxonomies?.find((t) => t.slug === rule.taxonomy)?.rest_base;
+				if (!restBase) {
+					return false;
+				}
+				const termIds = select('core/editor').getEditedPostAttribute(restBase) ?? [];
+				return termIds.includes(rule.term_id);
+			}) ?? null
+		);
+	}, []);
+	const lockingTerm = useSelect(
+		(select) =>
+			lockingRule
+				? select('core').getEntityRecord(
+						'taxonomy',
+						lockingRule.taxonomy,
+						lockingRule.term_id,
+					)
+				: null,
+		[lockingRule],
+	);
+
 	const {
 		_sesamy_locked,
 		_sesamy_access_level,
@@ -28,6 +60,9 @@ const SesamySettingsPanel = () => {
 		_sesamy_custom_paywall_url,
 		_sesamy_locked_content_redirect_url,
 	} = meta;
+
+	const isTermLocked = !!lockingRule;
+	const isEffectivelyLocked = _sesamy_locked || isTermLocked;
 
 	const [displayPrice, setDisplayPrice] = useState(_sesamy_price ? _sesamy_price.toString() : '');
 
@@ -70,13 +105,29 @@ const SesamySettingsPanel = () => {
 				<ToggleControl
 					__nextHasNoMarginBottom
 					label={__('Lock this article', 'sesamy')}
-					checked={_sesamy_locked}
+					checked={isEffectivelyLocked}
+					disabled={isTermLocked}
+					help={
+						isTermLocked
+							? sprintf(
+									/* translators: %s: name of the term that locks the article. */
+									__(
+										'Locked automatically by “%s”. Manage under Settings → Sesamy.',
+										'sesamy',
+									),
+									lockingTerm?.name ?? lockingRule.taxonomy,
+								)
+							: ''
+					}
 					onChange={(value) => {
+						// Term-locked posts never write `_sesamy_locked` — the
+						// control is disabled, this only fires for the per-post
+						// toggle.
 						editPost({ meta: { ...meta, _sesamy_locked: value } });
 					}}
 				/>
 			</PanelRow>
-			{_sesamy_locked && (
+			{isEffectivelyLocked && (
 				<>
 					{/* TODO: access level
 					<PanelRow>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+	bootstrap="tests/bootstrap.php"
+	colors="true"
+	cacheResultFile=".phpunit.result.cache"
+>
+	<testsuites>
+		<testsuite name="unit">
+			<directory>tests/src</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/src/Admin/Settings/Core.php
+++ b/src/Admin/Settings/Core.php
@@ -73,6 +73,20 @@ class Core {
 							'enabled_content_types' => [
 								'type' => 'array',
 							],
+							'locked_terms'          => [
+								'type'  => 'array',
+								'items' => [
+									'type'       => 'object',
+									'properties' => [
+										'taxonomy' => [
+											'type' => 'string',
+										],
+										'term_id'  => [
+											'type' => 'integer',
+										],
+									],
+								],
+							],
 							'development_mode'      => [
 								'type' => 'boolean',
 							],
@@ -125,6 +139,26 @@ class Core {
 					break;
 				case 'enabled_content_types':
 					$sanitized_input[ $key ] = array_map( 'sanitize_text_field', (array) $value );
+					break;
+				case 'locked_terms':
+					// Accepts both the settings-form encoding (`taxonomy:term_id`
+					// strings from the checkbox list) and the canonical REST shape
+					// (`{taxonomy, term_id}` objects); stores the canonical shape.
+					$rules = [];
+					foreach ( (array) $value as $rule ) {
+						if ( is_string( $rule ) && preg_match( '/^([a-z0-9_-]+):(\d+)$/i', $rule, $matches ) ) {
+							$rules[] = [
+								'taxonomy' => sanitize_key( $matches[1] ),
+								'term_id'  => (int) $matches[2],
+							];
+						} elseif ( is_array( $rule ) && ! empty( $rule['taxonomy'] ) && ! empty( $rule['term_id'] ) ) {
+							$rules[] = [
+								'taxonomy' => sanitize_key( (string) $rule['taxonomy'] ),
+								'term_id'  => absint( $rule['term_id'] ),
+							];
+						}
+					}
+					$sanitized_input[ $key ] = $rules;
 					break;
 				case 'development_mode':
 				case 'use_first_party_proxy':
@@ -235,6 +269,17 @@ class Core {
 			[
 				'name'      => 'default_pass',
 				'label_for' => 'default_pass',
+			]
+		);
+
+		add_settings_field(
+			'locked_terms',
+			__( 'Automatic locking', 'sesamy' ),
+			[ $settings_page_view, 'settings_render_locked_terms' ],
+			'sesamy',
+			'section_general',
+			[
+				'name' => 'locked_terms',
 			]
 		);
 

--- a/src/Admin/Settings/Core.php
+++ b/src/Admin/Settings/Core.php
@@ -152,10 +152,14 @@ class Core {
 								'term_id'  => (int) $matches[2],
 							];
 						} elseif ( is_array( $rule ) && ! empty( $rule['taxonomy'] ) && ! empty( $rule['term_id'] ) ) {
-							$rules[] = [
-								'taxonomy' => sanitize_key( (string) $rule['taxonomy'] ),
-								'term_id'  => absint( $rule['term_id'] ),
-							];
+							$taxonomy = sanitize_key( (string) $rule['taxonomy'] );
+							$term_id  = absint( $rule['term_id'] );
+							if ( '' !== $taxonomy && 0 < $term_id ) {
+								$rules[] = [
+									'taxonomy' => $taxonomy,
+									'term_id'  => $term_id,
+								];
+							}
 						}
 					}
 					$sanitized_input[ $key ] = $rules;

--- a/src/Admin/Settings/Core.php
+++ b/src/Admin/Settings/Core.php
@@ -144,23 +144,32 @@ class Core {
 					// Accepts both the settings-form encoding (`taxonomy:term_id`
 					// strings from the checkbox list) and the canonical REST shape
 					// (`{taxonomy, term_id}` objects); stores the canonical shape.
+					// Only rules for public, REST-exposed taxonomies are kept —
+					// the same constraint the settings UI applies — so no client
+					// can persist a rule the Gutenberg panel cannot resolve via
+					// the taxonomies REST API.
 					$rules = [];
 					foreach ( (array) $value as $rule ) {
 						if ( is_string( $rule ) && preg_match( '/^([a-z0-9_-]+):(\d+)$/i', $rule, $matches ) ) {
-							$rules[] = [
-								'taxonomy' => sanitize_key( $matches[1] ),
-								'term_id'  => (int) $matches[2],
-							];
+							$taxonomy = sanitize_key( $matches[1] );
+							$term_id  = (int) $matches[2];
 						} elseif ( is_array( $rule ) && ! empty( $rule['taxonomy'] ) && ! empty( $rule['term_id'] ) ) {
 							$taxonomy = sanitize_key( (string) $rule['taxonomy'] );
 							$term_id  = absint( $rule['term_id'] );
-							if ( '' !== $taxonomy && 0 < $term_id ) {
-								$rules[] = [
-									'taxonomy' => $taxonomy,
-									'term_id'  => $term_id,
-								];
-							}
+						} else {
+							continue;
 						}
+						if ( '' === $taxonomy || 0 >= $term_id ) {
+							continue;
+						}
+						$taxonomy_obj = get_taxonomy( $taxonomy );
+						if ( ! $taxonomy_obj || empty( $taxonomy_obj->public ) || empty( $taxonomy_obj->show_in_rest ) ) {
+							continue;
+						}
+						$rules[] = [
+							'taxonomy' => $taxonomy,
+							'term_id'  => $term_id,
+						];
 					}
 					$sanitized_input[ $key ] = $rules;
 					break;

--- a/src/Admin/Settings/Post.php
+++ b/src/Admin/Settings/Post.php
@@ -10,6 +10,7 @@ namespace SesamyPlugin\Admin\Settings;
 use function SesamyPlugin\Helpers\get_enabled_post_types;
 use function SesamyPlugin\Helpers\get_post_locking_term;
 use function SesamyPlugin\Helpers\is_config_valid;
+use function SesamyPlugin\Helpers\is_post_locked;
 
 /**
  * Post Settings module.
@@ -156,12 +157,13 @@ class Post {
 		if ( 'sesamy' === $column_name ) {
 			$is_meta_locked  = (bool) get_post_meta( $post_id, '_sesamy_locked', true );
 			$locking_term    = get_post_locking_term( $post_id );
-			$is_locked       = $is_meta_locked || null !== $locking_term;
+			$is_locked       = is_post_locked( $post_id );
 			$single_purchase = get_post_meta( $post_id, '_sesamy_enable_single_purchase', true );
 
 			// `column-sesamy_locked` must reflect the per-post meta only — the
 			// quick-edit checkbox is populated from this class (admin.js), and a
-			// term-driven lock must never round-trip into `_sesamy_locked`.
+			// term- or filter-driven lock must never round-trip into
+			// `_sesamy_locked`.
 			$value = '';
 			if ( $is_meta_locked ) {
 				$value = '<div class="column-sesamy_locked"><span class="dashicons dashicons-lock"></span> Locked</div>';
@@ -172,6 +174,9 @@ class Post {
 					? sprintf( '%s: %s', $taxonomy ? $taxonomy->labels->singular_name : $locking_term['taxonomy'], $term->name )
 					: $locking_term['taxonomy'];
 				$value    = '<div class="column-sesamy_term_locked"><span class="dashicons dashicons-lock"></span> Locked (' . esc_html( $source ) . ')</div>';
+			} elseif ( $is_locked ) {
+				// Locked via the `sesamy_is_post_locked` filter.
+				$value = '<div class="column-sesamy_term_locked"><span class="dashicons dashicons-lock"></span> Locked (filter)</div>';
 			}
 			$value .= $is_locked && $single_purchase ? '<div class="column-sesamy_single_purchase"><span class="dashicons dashicons-money-alt"></span> Single Purchase</div>' : '';
 			echo wp_kses_post( $value );

--- a/src/Admin/Settings/Post.php
+++ b/src/Admin/Settings/Post.php
@@ -8,6 +8,7 @@
 namespace SesamyPlugin\Admin\Settings;
 
 use function SesamyPlugin\Helpers\get_enabled_post_types;
+use function SesamyPlugin\Helpers\get_post_locking_term;
 use function SesamyPlugin\Helpers\is_config_valid;
 
 /**
@@ -153,10 +154,25 @@ class Post {
 	 */
 	public function populate_custom_column( $column_name, $post_id ) {
 		if ( 'sesamy' === $column_name ) {
-			$is_locked       = get_post_meta( $post_id, '_sesamy_locked', true );
+			$is_meta_locked  = (bool) get_post_meta( $post_id, '_sesamy_locked', true );
+			$locking_term    = get_post_locking_term( $post_id );
+			$is_locked       = $is_meta_locked || null !== $locking_term;
 			$single_purchase = get_post_meta( $post_id, '_sesamy_enable_single_purchase', true );
 
-			$value  = $is_locked ? '<div class="column-sesamy_locked"><span class="dashicons dashicons-lock"></span> Locked</div>' : '';
+			// `column-sesamy_locked` must reflect the per-post meta only — the
+			// quick-edit checkbox is populated from this class (admin.js), and a
+			// term-driven lock must never round-trip into `_sesamy_locked`.
+			$value = '';
+			if ( $is_meta_locked ) {
+				$value = '<div class="column-sesamy_locked"><span class="dashicons dashicons-lock"></span> Locked</div>';
+			} elseif ( null !== $locking_term ) {
+				$term     = get_term( $locking_term['term_id'], $locking_term['taxonomy'] );
+				$taxonomy = get_taxonomy( $locking_term['taxonomy'] );
+				$source   = $term instanceof \WP_Term
+					? sprintf( '%s: %s', $taxonomy ? $taxonomy->labels->singular_name : $locking_term['taxonomy'], $term->name )
+					: $locking_term['taxonomy'];
+				$value    = '<div class="column-sesamy_term_locked"><span class="dashicons dashicons-lock"></span> Locked (' . esc_html( $source ) . ')</div>';
+			}
 			$value .= $is_locked && $single_purchase ? '<div class="column-sesamy_single_purchase"><span class="dashicons dashicons-money-alt"></span> Single Purchase</div>' : '';
 			echo wp_kses_post( $value );
 		}

--- a/src/Admin/View/MetaBox.php
+++ b/src/Admin/View/MetaBox.php
@@ -8,6 +8,7 @@
 namespace SesamyPlugin\Admin\View;
 
 use function SesamyPlugin\Helpers\get_post_locking_term;
+use function SesamyPlugin\Helpers\is_post_locked;
 
 /**
  * MetaBox module.
@@ -37,7 +38,10 @@ class MetaBox {
 
 		$is_meta_locked = (bool) get_post_meta( $post->ID, '_sesamy_locked', true );
 		$locking_term   = get_post_locking_term( $post->ID );
-		$is_locked      = $is_meta_locked || null !== $locking_term;
+		// Effective state (meta OR term OR `sesamy_is_post_locked` filter)
+		// drives the dependent fields below, so they stay in sync with what
+		// the front end actually renders.
+		$is_locked = is_post_locked( $post->ID );
 
 		echo '<div class="misc-pub-section">';
 		if ( null !== $locking_term ) {

--- a/src/Admin/View/MetaBox.php
+++ b/src/Admin/View/MetaBox.php
@@ -7,6 +7,8 @@
 
 namespace SesamyPlugin\Admin\View;
 
+use function SesamyPlugin\Helpers\get_post_locking_term;
+
 /**
  * MetaBox module.
  *
@@ -33,9 +35,36 @@ class MetaBox {
 		// We'll use this nonce field later on when saving.
 		wp_nonce_field( 'sesamy_post_meta_box_nonce', 'post_meta_box_nonce' );
 
-		$is_locked = get_post_meta( $post->ID, '_sesamy_locked', true );
+		$is_meta_locked = (bool) get_post_meta( $post->ID, '_sesamy_locked', true );
+		$locking_term   = get_post_locking_term( $post->ID );
+		$is_locked      = $is_meta_locked || null !== $locking_term;
+
 		echo '<div class="misc-pub-section">';
-		echo '<label><input value="1" type="checkbox" name="sesamy_meta_box_locked" id="sesamy_meta_box_locked" ' . checked( $is_locked, true, false ) . ' /> ' . esc_html( __( 'Lock this article', 'sesamy' ) ) . '</label>';
+		if ( null !== $locking_term ) {
+			// Term-locked: the checkbox is display-only (checked + disabled) and
+			// the rule never writes `_sesamy_locked`. Disabled inputs don't
+			// submit, so a hidden field preserves the underlying per-post toggle
+			// across saves (`save_meta_box_postdata` keys off isset).
+			if ( $is_meta_locked ) {
+				echo '<input type="hidden" name="sesamy_meta_box_locked" value="1" />';
+			}
+			echo '<label><input value="1" type="checkbox" id="sesamy_meta_box_locked" checked disabled /> ' . esc_html( __( 'Lock this article', 'sesamy' ) ) . '</label>';
+
+			$term          = get_term( $locking_term['term_id'], $locking_term['taxonomy'] );
+			$taxonomy      = get_taxonomy( $locking_term['taxonomy'] );
+			$taxonomy_name = $taxonomy ? strtolower( $taxonomy->labels->singular_name ) : $locking_term['taxonomy'];
+			$term_name     = $term instanceof \WP_Term ? $term->name : (string) $locking_term['term_id'];
+			echo '<p class="description">' . esc_html(
+				sprintf(
+					/* translators: 1: taxonomy singular name (e.g. category), 2: term name. */
+					__( 'Locked automatically by %1$s “%2$s”. Manage under Settings → Sesamy.', 'sesamy' ),
+					$taxonomy_name,
+					$term_name
+				)
+			) . '</p>';
+		} else {
+			echo '<label><input value="1" type="checkbox" name="sesamy_meta_box_locked" id="sesamy_meta_box_locked" ' . checked( $is_meta_locked, true, false ) . ' /> ' . esc_html( __( 'Lock this article', 'sesamy' ) ) . '</label>';
+		}
 		echo '</div>';
 
 		if ( $is_locked ) {

--- a/src/Admin/View/SettingsPage.php
+++ b/src/Admin/View/SettingsPage.php
@@ -652,7 +652,11 @@ class SettingsPage {
 		$taxonomies = [];
 		foreach ( get_enabled_post_types() as $post_type ) {
 			foreach ( get_object_taxonomies( (string) $post_type, 'objects' ) as $taxonomy ) {
-				if ( ! empty( $taxonomy->public ) ) {
+				// Require REST exposure so the Gutenberg panel (which resolves
+				// rules via the taxonomies REST API) sees the same rule set the
+				// backend enforces — a public-but-non-REST taxonomy would lock
+				// posts the editor can't explain.
+				if ( ! empty( $taxonomy->public ) && ! empty( $taxonomy->show_in_rest ) ) {
 					$taxonomies[ $taxonomy->name ] = $taxonomy;
 				}
 			}

--- a/src/Admin/View/SettingsPage.php
+++ b/src/Admin/View/SettingsPage.php
@@ -662,7 +662,8 @@ class SettingsPage {
 			}
 		}
 
-		$rendered_any = false;
+		$rendered_any    = false;
+		$rendered_values = [];
 		echo '<fieldset>';
 		foreach ( $taxonomies as $taxonomy ) {
 			$terms = get_terms(
@@ -675,17 +676,30 @@ class SettingsPage {
 				continue;
 			}
 			$rendered_any = true;
-			echo '<strong>' . esc_html( $taxonomy->labels->name ) . '</strong><br>';
+			// A nested fieldset with a legend gives each taxonomy's checkboxes a
+			// semantic group label instead of a presentational heading.
+			echo '<fieldset><legend>' . esc_html( $taxonomy->labels->name ) . '</legend>';
 			foreach ( $terms as $term ) {
-				$value   = $taxonomy->name . ':' . $term->term_id;
-				$checked = checked( in_array( $value, $selected, true ), true, false );
+				$value             = $taxonomy->name . ':' . $term->term_id;
+				$rendered_values[] = $value;
+				$checked           = checked( in_array( $value, $selected, true ), true, false );
 				echo '<label><input type="checkbox" name="sesamy_settings[' . esc_attr( $field_name ) . '][]" value="' . esc_attr( $value ) . '" ' . esc_attr( $checked ) . '>' . esc_html( $term->name ) . '</label><br>';
 			}
+			echo '</fieldset>';
+		}
+
+		// Checkboxes only submit checked values, so a selected rule whose term
+		// wasn't rendered (its taxonomy's get_terms() failed or the term is no
+		// longer returned) would be silently dropped on save. Preserve those
+		// via hidden inputs; the sanitizer keeps them as long as the taxonomy
+		// is still public and REST-exposed.
+		foreach ( array_diff( $selected, $rendered_values ) as $value ) {
+			echo '<input type="hidden" name="sesamy_settings[' . esc_attr( $field_name ) . '][]" value="' . esc_attr( $value ) . '">';
 		}
 		echo '</fieldset>';
 
 		if ( ! $rendered_any ) {
-			echo '<p class="description">' . esc_html__( 'No categories or tags found for the enabled content types.', 'sesamy2' ) . '</p>';
+			echo '<p class="description">' . esc_html__( 'No terms found for the enabled content types.', 'sesamy2' ) . '</p>';
 			return;
 		}
 		echo '<p class="description">' . esc_html__( 'Articles with any of these terms are always locked, in addition to articles locked individually. On sites with full-page caching, flush the cache after changing this.', 'sesamy2' ) . '</p>';

--- a/src/Admin/View/SettingsPage.php
+++ b/src/Admin/View/SettingsPage.php
@@ -10,6 +10,8 @@ namespace SesamyPlugin\Admin\View;
 use SesamyPlugin\Capsule\Registration;
 use SesamyPlugin\Connect\SesamyApi;
 
+use function SesamyPlugin\Helpers\get_enabled_post_types;
+use function SesamyPlugin\Helpers\get_locked_term_rules;
 use function SesamyPlugin\Helpers\get_sesamy_connection;
 use function SesamyPlugin\Helpers\get_sesamy_setting;
 use function SesamyPlugin\Helpers\is_sesamy_connected;
@@ -626,6 +628,63 @@ class SettingsPage {
 			echo '<label><input type="checkbox" name="sesamy_settings[' . esc_attr( $args['name'] ) . '][]" value="' . esc_attr( $value ) . '" ' . esc_attr( $checked ) . '>' . esc_html( $label ) . '</label><br>';
 		}
 		echo '</fieldset>';
+	}
+
+	/**
+	 * "Automatic locking" term list render. One checkbox group per public
+	 * taxonomy of the enabled content types. Values are encoded as
+	 * `taxonomy:term_id` and decoded to `{taxonomy, term_id}` objects by
+	 * `Core::sanitize_sesamy_settings()`.
+	 *
+	 * @param array{name: string} $args Arguments of the locked terms field.
+	 *
+	 * @return void
+	 */
+	public function settings_render_locked_terms( $args ) {
+		$field_name = $args['name'];
+		$selected   = array_map(
+			static function ( $rule ) {
+				return $rule['taxonomy'] . ':' . $rule['term_id'];
+			},
+			get_locked_term_rules()
+		);
+
+		$taxonomies = [];
+		foreach ( get_enabled_post_types() as $post_type ) {
+			foreach ( get_object_taxonomies( (string) $post_type, 'objects' ) as $taxonomy ) {
+				if ( ! empty( $taxonomy->public ) ) {
+					$taxonomies[ $taxonomy->name ] = $taxonomy;
+				}
+			}
+		}
+
+		$rendered_any = false;
+		echo '<fieldset>';
+		foreach ( $taxonomies as $taxonomy ) {
+			$terms = get_terms(
+				[
+					'taxonomy'   => $taxonomy->name,
+					'hide_empty' => false,
+				]
+			);
+			if ( is_wp_error( $terms ) || empty( $terms ) ) {
+				continue;
+			}
+			$rendered_any = true;
+			echo '<strong>' . esc_html( $taxonomy->labels->name ) . '</strong><br>';
+			foreach ( $terms as $term ) {
+				$value   = $taxonomy->name . ':' . $term->term_id;
+				$checked = checked( in_array( $value, $selected, true ), true, false );
+				echo '<label><input type="checkbox" name="sesamy_settings[' . esc_attr( $field_name ) . '][]" value="' . esc_attr( $value ) . '" ' . esc_attr( $checked ) . '>' . esc_html( $term->name ) . '</label><br>';
+			}
+		}
+		echo '</fieldset>';
+
+		if ( ! $rendered_any ) {
+			echo '<p class="description">' . esc_html__( 'No categories or tags found for the enabled content types.', 'sesamy2' ) . '</p>';
+			return;
+		}
+		echo '<p class="description">' . esc_html__( 'Articles with any of these terms are always locked, in addition to articles locked individually. On sites with full-page caching, flush the cache after changing this.', 'sesamy2' ) . '</p>';
 	}
 
 	/**

--- a/src/Api/Rest.php
+++ b/src/Api/Rest.php
@@ -11,6 +11,7 @@ use Firebase\JWT\JWK;
 use Firebase\JWT\JWT;
 
 use function SesamyPlugin\Helpers\get_sesamy_environment;
+use function SesamyPlugin\Helpers\is_post_locked;
 
 /**
  * Rest module.
@@ -75,7 +76,7 @@ class Rest {
 			return new \WP_Error( 404, __( 'Post not found.', 'sesamy' ) );
 		}
 
-		$is_locked = get_post_meta( $post->ID, '_sesamy_locked', true );
+		$is_locked = is_post_locked( $post->ID );
 
 		if ( $is_locked ) {
 			$auth_header = (string) $request->get_header( 'authorization' );

--- a/src/Frontend/ContentContainer.php
+++ b/src/Frontend/ContentContainer.php
@@ -14,6 +14,7 @@ use function SesamyPlugin\Helpers\get_sesamy_environment;
 use function SesamyPlugin\Helpers\get_sesamy_setting;
 use function SesamyPlugin\Helpers\get_sesamy_vendor_id;
 use function SesamyPlugin\Helpers\is_config_valid;
+use function SesamyPlugin\Helpers\is_post_locked;
 
 /**
  * ContentContainer module.
@@ -74,10 +75,9 @@ class ContentContainer {
 	 * @return string
 	 */
 	public function process_content( $post, $content ) {
-		$is_locked = get_post_meta( $post->ID, '_sesamy_locked', true );
+		$is_locked = is_post_locked( $post->ID );
 		// If not locked, always use 'embed' lock mode
-		// Check if the value indicates locked content (truthy and not '0')
-		if ( empty( $is_locked ) || '0' === $is_locked ) {
+		if ( ! $is_locked ) {
 			$lock_mode = 'embed';
 		} else {
 			$lock_mode = get_sesamy_setting( 'lock_mode' );

--- a/src/Frontend/Meta.php
+++ b/src/Frontend/Meta.php
@@ -10,6 +10,7 @@ namespace SesamyPlugin\Frontend;
 use function SesamyPlugin\Helpers\get_enabled_post_types;
 use function SesamyPlugin\Helpers\get_sesamy_vendor_id;
 use function SesamyPlugin\Helpers\is_config_valid;
+use function SesamyPlugin\Helpers\is_post_locked;
 
 /**
  * Meta module.
@@ -72,7 +73,7 @@ class Meta {
 		}
 
 		if ( is_singular() ) {
-			$is_locked    = (bool) ( get_post_meta( $post->ID, '_sesamy_locked', true ) ?? false );
+			$is_locked    = is_post_locked( $post->ID );
 			$access_level = $is_locked ? get_post_meta( $post->ID, '_sesamy_access_level', true ) : 'public';
 			if ( ! empty( $access_level ) ) {
 				echo '<meta name="sesamy:accessLevel" content="' . esc_attr( $access_level ) . '">';

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -85,6 +85,72 @@ function get_enabled_post_types() {
 }
 
 /**
+ * Parsed "Automatic locking" term rules from the `locked_terms` setting.
+ *
+ * Each rule is `['taxonomy' => string, 'term_id' => int]`. The object shape is
+ * deliberate — a future per-term `pass` key (capsule scope mapping) can be
+ * added without a settings migration.
+ *
+ * @return array<int, array{taxonomy: string, term_id: int}>
+ */
+function get_locked_term_rules() {
+	$raw = get_sesamy_setting( 'locked_terms' );
+	if ( ! is_array( $raw ) ) {
+		return [];
+	}
+	$rules = [];
+	foreach ( $raw as $rule ) {
+		if ( is_array( $rule ) && ! empty( $rule['taxonomy'] ) && ! empty( $rule['term_id'] ) ) {
+			$rules[] = [
+				'taxonomy' => (string) $rule['taxonomy'],
+				'term_id'  => (int) $rule['term_id'],
+			];
+		}
+	}
+	return $rules;
+}
+
+/**
+ * First "Automatic locking" rule matching the post's terms, or null.
+ *
+ * Evaluated at read time (`has_term`) rather than synced to post meta, so
+ * rules apply retroactively and removing a term immediately unlocks.
+ *
+ * @param \WP_Post|int $post Post object or id.
+ * @return array{taxonomy: string, term_id: int}|null
+ */
+function get_post_locking_term( $post ) {
+	$post_id = $post instanceof \WP_Post ? (int) $post->ID : (int) $post;
+	foreach ( get_locked_term_rules() as $rule ) {
+		if ( has_term( $rule['term_id'], $rule['taxonomy'], $post_id ) ) {
+			return $rule;
+		}
+	}
+	return null;
+}
+
+/**
+ * Effective lock state for a post — the single source of truth consumed by
+ * rendering, head meta tags, REST, and admin UI.
+ *
+ * Locked when the per-post `_sesamy_locked` meta is set OR the post has a
+ * term selected under "Automatic locking" (additive; the rule never writes
+ * post meta). The result passes through the `sesamy_is_post_locked` filter
+ * as an escape hatch for bespoke lock rules.
+ *
+ * @param \WP_Post|int $post Post object or id.
+ * @return bool
+ */
+function is_post_locked( $post ) {
+	$post_id = $post instanceof \WP_Post ? (int) $post->ID : (int) $post;
+	$locked  = ! empty( get_post_meta( $post_id, '_sesamy_locked', true ) );
+	if ( ! $locked && null !== get_post_locking_term( $post_id ) ) {
+		$locked = true;
+	}
+	return (bool) apply_filters( 'sesamy_is_post_locked', $locked, $post_id );
+}
+
+/**
  * Get the stored Sesamy connection bundle written at the end of the connect flow.
  *
  * Synthesizes a stub bundle from legacy `sesamy_settings.client_id` when no

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * PHPUnit bootstrap: composer autoload + WP_Mock.
+ *
+ * @package Sesamy2
+ */
+
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+
+WP_Mock::bootstrap();

--- a/tests/src/Admin/Settings/CoreTest.php
+++ b/tests/src/Admin/Settings/CoreTest.php
@@ -1,0 +1,105 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use WP_Mock;
+
+class CoreTest extends TestCase {
+	protected $core;
+
+	protected function setUp(): void {
+		WP_Mock::setUp();
+		$this->core = new SesamyPlugin\Admin\Settings\Core();
+	}
+
+	protected function tearDown(): void {
+		WP_Mock::tearDown();
+	}
+
+	private function mockSanitizers() {
+		WP_Mock::userFunction(
+			'sanitize_key',
+			[
+				'return' => function ( $key ) {
+					return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $key ) );
+				},
+			]
+		);
+		WP_Mock::userFunction(
+			'absint',
+			[
+				'return' => function ( $value ) {
+					return abs( (int) $value );
+				},
+			]
+		);
+	}
+
+	public function test_sanitize_locked_terms_parses_form_encoding() {
+		$this->mockSanitizers();
+
+		$result = $this->core->sanitize_sesamy_settings( [ 'locked_terms' => [ 'category:12', 'post_tag:34' ] ] );
+
+		$this->assertSame(
+			[
+				[
+					'taxonomy' => 'category',
+					'term_id'  => 12,
+				],
+				[
+					'taxonomy' => 'post_tag',
+					'term_id'  => 34,
+				],
+			],
+			$result['locked_terms']
+		);
+	}
+
+	public function test_sanitize_locked_terms_accepts_canonical_rest_shape() {
+		$this->mockSanitizers();
+
+		$result = $this->core->sanitize_sesamy_settings(
+			[
+				'locked_terms' => [
+					[
+						'taxonomy' => 'category',
+						'term_id'  => '12',
+					],
+				],
+			]
+		);
+
+		$this->assertSame(
+			[
+				[
+					'taxonomy' => 'category',
+					'term_id'  => 12,
+				],
+			],
+			$result['locked_terms']
+		);
+	}
+
+	public function test_sanitize_locked_terms_drops_malformed_values() {
+		$this->mockSanitizers();
+
+		$result = $this->core->sanitize_sesamy_settings(
+			[
+				'locked_terms' => [
+					'no-term-id',
+					'category:',
+					[ 'taxonomy' => 'category' ],
+					'category:12',
+				],
+			]
+		);
+
+		$this->assertSame(
+			[
+				[
+					'taxonomy' => 'category',
+					'term_id'  => 12,
+				],
+			],
+			$result['locked_terms']
+		);
+	}
+}

--- a/tests/src/Admin/Settings/CoreTest.php
+++ b/tests/src/Admin/Settings/CoreTest.php
@@ -31,6 +31,27 @@ class CoreTest extends TestCase {
 				},
 			]
 		);
+		// Only `category` and `post_tag` exist as public + REST-exposed.
+		WP_Mock::userFunction(
+			'get_taxonomy',
+			[
+				'return' => function ( $taxonomy ) {
+					if ( in_array( $taxonomy, [ 'category', 'post_tag' ], true ) ) {
+						return (object) [
+							'public'       => true,
+							'show_in_rest' => true,
+						];
+					}
+					if ( 'internal_tax' === $taxonomy ) {
+						return (object) [
+							'public'       => true,
+							'show_in_rest' => false,
+						];
+					}
+					return false;
+				},
+			]
+		);
 	}
 
 	public function test_sanitize_locked_terms_parses_form_encoding() {
@@ -95,6 +116,17 @@ class CoreTest extends TestCase {
 						'taxonomy' => 'category',
 						'term_id'  => 'abc',
 					],
+					// Unregistered and non-REST taxonomies are rejected even in
+					// the canonical shape — the settings contract, not just the UI.
+					[
+						'taxonomy' => 'ghost_tax',
+						'term_id'  => 7,
+					],
+					[
+						'taxonomy' => 'internal_tax',
+						'term_id'  => 8,
+					],
+					'internal_tax:9',
 					'category:12',
 				],
 			]

--- a/tests/src/Admin/Settings/CoreTest.php
+++ b/tests/src/Admin/Settings/CoreTest.php
@@ -87,6 +87,14 @@ class CoreTest extends TestCase {
 					'no-term-id',
 					'category:',
 					[ 'taxonomy' => 'category' ],
+					[
+						'taxonomy' => '!!!',
+						'term_id'  => 5,
+					],
+					[
+						'taxonomy' => 'category',
+						'term_id'  => 'abc',
+					],
 					'category:12',
 				],
 			]

--- a/tests/src/Frontend/ContentContainerTest.php
+++ b/tests/src/Frontend/ContentContainerTest.php
@@ -125,17 +125,19 @@ class ContentContainerTest extends TestCase {
 		$this->assertStringContainsString( '<div slot="content">Test content</div>', $result );
 	}
 
-	public function test_process_content_locks_article_via_term_rule() {
-		$postId = 789;
-		// Meta says unlocked, but a locked_terms rule matches the post.
-		WP_Mock::userFunction( 'get_the_ID', [ 'return' => $postId ] );
+	/**
+	 * Set up mocks for a post that is locked only via a matching `locked_terms`
+	 * rule (per-post `_sesamy_locked` meta stays unset) under the given lock mode.
+	 */
+	private function setupTermLockMocks( $post_id, $lockMode ) {
+		WP_Mock::userFunction( 'get_the_ID', [ 'return' => $post_id ] );
 		WP_Mock::userFunction( 'get_the_excerpt', [ 'return' => 'Preview' ] );
 		WP_Mock::userFunction(
 			'get_option',
 			[
 				'args'   => [ 'sesamy_settings' ],
 				'return' => [
-					'lock_mode'    => 'encode',
+					'lock_mode'    => $lockMode,
 					'locked_terms' => [
 						[
 							'taxonomy' => 'category',
@@ -157,42 +159,42 @@ class ContentContainerTest extends TestCase {
 		WP_Mock::userFunction(
 			'get_permalink',
 			[
-				'args'   => [ $postId ],
-				'return' => "https://example.com/post/{$postId}",
+				'args'   => [ $post_id ],
+				'return' => "https://example.com/post/{$post_id}",
 			]
 		);
 		WP_Mock::userFunction(
 			'get_post_meta',
 			[
-				'args'   => [ $postId, '_sesamy_locked', true ],
+				'args'   => [ $post_id, '_sesamy_locked', true ],
 				'return' => '',
 			]
 		);
 		WP_Mock::userFunction(
 			'get_post_meta',
 			[
-				'args'   => [ $postId, '_sesamy_custom_paywall_url', true ],
+				'args'   => [ $post_id, '_sesamy_custom_paywall_url', true ],
 				'return' => '',
 			]
 		);
 		WP_Mock::userFunction(
 			'get_post_meta',
 			[
-				'args'   => [ $postId, '_sesamy_locked_content_redirect_url', true ],
+				'args'   => [ $post_id, '_sesamy_locked_content_redirect_url', true ],
 				'return' => '',
 			]
 		);
 		WP_Mock::userFunction(
 			'has_term',
 			[
-				'args'   => [ 12, 'category', $postId ],
+				'args'   => [ 12, 'category', $post_id ],
 				'return' => true,
 			]
 		);
 		WP_Mock::userFunction(
 			'apply_filters',
 			[
-				'args'       => [ 'sesamy_is_post_locked', WP_Mock\Functions::type( 'bool' ), $postId ],
+				'args'       => [ 'sesamy_is_post_locked', WP_Mock\Functions::type( 'bool' ), $post_id ],
 				'return_arg' => 1,
 			]
 		);
@@ -210,9 +212,15 @@ class ContentContainerTest extends TestCase {
 				'return' => '',
 			]
 		);
+	}
+
+	public function test_process_content_locks_article_via_term_rule() {
+		$post_id = 789;
+		// Meta says unlocked, but a locked_terms rule matches the post.
+		$this->setupTermLockMocks( $post_id, 'encode' );
 
 		$post = (object) [
-			'ID'           => $postId,
+			'ID'           => $post_id,
 			'post_content' => 'Term locked content',
 		];
 
@@ -220,6 +228,23 @@ class ContentContainerTest extends TestCase {
 
 		$this->assertStringContainsString( 'lock-mode="encode"', $result );
 		$this->assertStringContainsString( 'style="display:none;">' . base64_encode( 'Term locked content' ), $result );
+	}
+
+	public function test_process_content_honors_embed_lock_mode_for_term_rule() {
+		$post_id = 790;
+		// Same term-locked scenario, but the plugin lock mode is `embed`, so the
+		// content must render visibly inside the container (no base64 encoding).
+		$this->setupTermLockMocks( $post_id, 'embed' );
+
+		$post = (object) [
+			'ID'           => $post_id,
+			'post_content' => 'Term locked content',
+		];
+
+		$result = $this->contentContainer->process_content( $post, 'Term locked content' );
+
+		$this->assertStringContainsString( 'lock-mode="embed"', $result );
+		$this->assertStringContainsString( '<div slot="content">Term locked content</div>', $result );
 	}
 
 	public function test_process_content_uses_plugin_setting_for_locked_article() {

--- a/tests/src/Frontend/ContentContainerTest.php
+++ b/tests/src/Frontend/ContentContainerTest.php
@@ -81,6 +81,13 @@ class ContentContainerTest extends TestCase {
 		WP_Mock::userFunction(
 			'apply_filters',
 			[
+				'args'       => [ 'sesamy_is_post_locked', WP_Mock\Functions::type( 'bool' ), $postId ],
+				'return_arg' => 1,
+			]
+		);
+		WP_Mock::userFunction(
+			'apply_filters',
+			[
 				'args'   => [ 'sesamy_paywall_preview', WP_Mock\Functions::type( 'string' ) ],
 				'return' => 'Preview',
 			]
@@ -116,6 +123,103 @@ class ContentContainerTest extends TestCase {
 
 		$this->assertStringContainsString( 'lock-mode="embed"', $result );
 		$this->assertStringContainsString( '<div slot="content">Test content</div>', $result );
+	}
+
+	public function test_process_content_locks_article_via_term_rule() {
+		$postId = 789;
+		// Meta says unlocked, but a locked_terms rule matches the post.
+		WP_Mock::userFunction( 'get_the_ID', [ 'return' => $postId ] );
+		WP_Mock::userFunction( 'get_the_excerpt', [ 'return' => 'Preview' ] );
+		WP_Mock::userFunction(
+			'get_option',
+			[
+				'args'   => [ 'sesamy_settings' ],
+				'return' => [
+					'lock_mode'    => 'encode',
+					'locked_terms' => [
+						[
+							'taxonomy' => 'category',
+							'term_id'  => 12,
+						],
+					],
+				],
+			]
+		);
+		WP_Mock::userFunction(
+			'get_extended',
+			[
+				'return' => [
+					'main'     => 'Preview',
+					'extended' => '',
+				],
+			]
+		);
+		WP_Mock::userFunction(
+			'get_permalink',
+			[
+				'args'   => [ $postId ],
+				'return' => "https://example.com/post/{$postId}",
+			]
+		);
+		WP_Mock::userFunction(
+			'get_post_meta',
+			[
+				'args'   => [ $postId, '_sesamy_locked', true ],
+				'return' => '',
+			]
+		);
+		WP_Mock::userFunction(
+			'get_post_meta',
+			[
+				'args'   => [ $postId, '_sesamy_custom_paywall_url', true ],
+				'return' => '',
+			]
+		);
+		WP_Mock::userFunction(
+			'get_post_meta',
+			[
+				'args'   => [ $postId, '_sesamy_locked_content_redirect_url', true ],
+				'return' => '',
+			]
+		);
+		WP_Mock::userFunction(
+			'has_term',
+			[
+				'args'   => [ 12, 'category', $postId ],
+				'return' => true,
+			]
+		);
+		WP_Mock::userFunction(
+			'apply_filters',
+			[
+				'args'       => [ 'sesamy_is_post_locked', WP_Mock\Functions::type( 'bool' ), $postId ],
+				'return_arg' => 1,
+			]
+		);
+		WP_Mock::userFunction(
+			'apply_filters',
+			[
+				'args'   => [ 'sesamy_paywall_preview', WP_Mock\Functions::type( 'string' ) ],
+				'return' => 'Preview',
+			]
+		);
+		WP_Mock::userFunction(
+			'apply_filters',
+			[
+				'args'   => [ 'sesamy_paywall', WP_Mock\Functions::type( 'string' ) ],
+				'return' => '',
+			]
+		);
+
+		$post = (object) [
+			'ID'           => $postId,
+			'post_content' => 'Term locked content',
+		];
+
+		$result = $this->contentContainer->process_content( $post, 'Term locked content' );
+
+		$this->assertStringContainsString( 'lock-mode="encode"', $result );
+		$this->assertStringContainsString( 'style="display:none;">' . base64_encode( 'Term locked content' ), $result );
 	}
 
 	public function test_process_content_uses_plugin_setting_for_locked_article() {

--- a/tests/src/Support/LockHelpersTest.php
+++ b/tests/src/Support/LockHelpersTest.php
@@ -1,0 +1,173 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use WP_Mock;
+
+use function SesamyPlugin\Helpers\get_locked_term_rules;
+use function SesamyPlugin\Helpers\get_post_locking_term;
+use function SesamyPlugin\Helpers\is_post_locked;
+
+class LockHelpersTest extends TestCase {
+	protected function setUp(): void {
+		WP_Mock::setUp();
+	}
+
+	protected function tearDown(): void {
+		WP_Mock::tearDown();
+	}
+
+	private function mockSettings( array $settings ) {
+		WP_Mock::userFunction(
+			'get_option',
+			[
+				'args'   => [ 'sesamy_settings' ],
+				'return' => $settings,
+			]
+		);
+	}
+
+	private function mockLockedMeta( int $postId, $value ) {
+		WP_Mock::userFunction(
+			'get_post_meta',
+			[
+				'args'   => [ $postId, '_sesamy_locked', true ],
+				'return' => $value,
+			]
+		);
+	}
+
+	private function mockLockFilterPassthrough( int $postId ) {
+		WP_Mock::userFunction(
+			'apply_filters',
+			[
+				'args'       => [ 'sesamy_is_post_locked', WP_Mock\Functions::type( 'bool' ), $postId ],
+				'return_arg' => 1,
+			]
+		);
+	}
+
+	public function test_meta_locked_post_is_locked() {
+		$this->mockLockedMeta( 1, '1' );
+		$this->mockLockFilterPassthrough( 1 );
+
+		$this->assertTrue( is_post_locked( 1 ) );
+	}
+
+	public function test_unlocked_post_without_rules_is_not_locked() {
+		$this->mockSettings( [] );
+		$this->mockLockedMeta( 2, '' );
+		$this->mockLockFilterPassthrough( 2 );
+
+		$this->assertFalse( is_post_locked( 2 ) );
+	}
+
+	public function test_legacy_zero_string_meta_is_not_locked() {
+		$this->mockSettings( [] );
+		$this->mockLockedMeta( 3, '0' );
+		$this->mockLockFilterPassthrough( 3 );
+
+		$this->assertFalse( is_post_locked( 3 ) );
+	}
+
+	public function test_term_rule_locks_post_without_meta() {
+		$this->mockSettings( [ 'locked_terms' => [ [ 'taxonomy' => 'category', 'term_id' => 12 ] ] ] );
+		$this->mockLockedMeta( 4, '' );
+		WP_Mock::userFunction(
+			'has_term',
+			[
+				'args'   => [ 12, 'category', 4 ],
+				'return' => true,
+			]
+		);
+		$this->mockLockFilterPassthrough( 4 );
+
+		$this->assertTrue( is_post_locked( 4 ) );
+	}
+
+	public function test_non_matching_term_rule_leaves_post_unlocked() {
+		$this->mockSettings( [ 'locked_terms' => [ [ 'taxonomy' => 'category', 'term_id' => 12 ] ] ] );
+		$this->mockLockedMeta( 5, '' );
+		WP_Mock::userFunction(
+			'has_term',
+			[
+				'args'   => [ 12, 'category', 5 ],
+				'return' => false,
+			]
+		);
+		$this->mockLockFilterPassthrough( 5 );
+
+		$this->assertFalse( is_post_locked( 5 ) );
+	}
+
+	public function test_accepts_numeric_string_id() {
+		$this->mockLockedMeta( 6, '1' );
+		$this->mockLockFilterPassthrough( 6 );
+
+		$this->assertTrue( is_post_locked( '6' ) );
+	}
+
+	public function test_filter_can_override_lock_state() {
+		$this->mockSettings( [] );
+		$this->mockLockedMeta( 7, '' );
+		WP_Mock::onFilter( 'sesamy_is_post_locked' )
+			->with( false, 7 )
+			->reply( true );
+
+		$this->assertTrue( is_post_locked( 7 ) );
+	}
+
+	public function test_get_post_locking_term_returns_first_match() {
+		$this->mockSettings(
+			[
+				'locked_terms' => [
+					[ 'taxonomy' => 'category', 'term_id' => 12 ],
+					[ 'taxonomy' => 'post_tag', 'term_id' => 34 ],
+				],
+			]
+		);
+		WP_Mock::userFunction(
+			'has_term',
+			[
+				'args'   => [ 12, 'category', 8 ],
+				'return' => false,
+			]
+		);
+		WP_Mock::userFunction(
+			'has_term',
+			[
+				'args'   => [ 34, 'post_tag', 8 ],
+				'return' => true,
+			]
+		);
+
+		$this->assertSame(
+			[
+				'taxonomy' => 'post_tag',
+				'term_id'  => 34,
+			],
+			get_post_locking_term( 8 )
+		);
+	}
+
+	public function test_get_locked_term_rules_skips_malformed_entries() {
+		$this->mockSettings(
+			[
+				'locked_terms' => [
+					[ 'taxonomy' => 'category', 'term_id' => '12' ],
+					[ 'taxonomy' => '' ],
+					'not-an-array',
+					[ 'term_id' => 5 ],
+				],
+			]
+		);
+
+		$this->assertSame(
+			[
+				[
+					'taxonomy' => 'category',
+					'term_id'  => 12,
+				],
+			],
+			get_locked_term_rules()
+		);
+	}
+}

--- a/tests/src/Support/UrlHelperTest.php
+++ b/tests/src/Support/UrlHelperTest.php
@@ -16,15 +16,28 @@ class UrlHelperTest extends TestCase {
 	}
 
 	/**
-	 * Mock the inputs `sesamy_url()` reads: the `development_mode` setting
-	 * (via the `sesamy_settings` option) and the `sesamy_routing` option.
+	 * Mock the inputs `sesamy_url()` reads: no stored connection bundle, the
+	 * `development_mode` setting (via the `sesamy_settings` option) and the
+	 * `sesamy_routing` option. `use_first_party_proxy` is stored as an
+	 * explicit null so routing falls through to the legacy `sesamy_routing`
+	 * option these tests exercise.
 	 */
 	private function set_state( bool $dev_mode, array $routing ): void {
 		WP_Mock::userFunction(
 			'get_option',
 			[
+				'args'   => [ 'sesamy_connection' ],
+				'return' => false,
+			]
+		);
+		WP_Mock::userFunction(
+			'get_option',
+			[
 				'args'   => [ 'sesamy_settings' ],
-				'return' => [ 'development_mode' => $dev_mode ],
+				'return' => [
+					'development_mode'      => $dev_mode,
+					'use_first_party_proxy' => null,
+				],
 			]
 		);
 		WP_Mock::userFunction(
@@ -116,23 +129,23 @@ class UrlHelperTest extends TestCase {
 	}
 
 	public function test_routing_mode_helper_defaults_to_direct() {
-		WP_Mock::userFunction(
-			'get_option',
-			[
-				'args'   => [ 'sesamy_routing', [] ],
-				'return' => [],
-			]
-		);
+		$this->set_state( false, [] );
 
 		$this->assertSame( 'direct', get_sesamy_routing_mode() );
 	}
 
 	public function test_routing_mode_helper_reads_wordpress_proxy() {
+		$this->set_state( false, [ 'mode' => 'wordpress_proxy' ] );
+
+		$this->assertSame( 'wordpress_proxy', get_sesamy_routing_mode() );
+	}
+
+	public function test_routing_mode_helper_prefers_proxy_toggle() {
 		WP_Mock::userFunction(
 			'get_option',
 			[
-				'args'   => [ 'sesamy_routing', [] ],
-				'return' => [ 'mode' => 'wordpress_proxy' ],
+				'args'   => [ 'sesamy_settings' ],
+				'return' => [ 'use_first_party_proxy' => true ],
 			]
 		);
 


### PR DESCRIPTION
Implements #43 — lock articles automatically by category/tag, the main migration path for publishers coming from MemberPress and other rule-based membership plugins.

## Semantics

An article is locked when **its per-post toggle is on OR it has a term selected under the new "Automatic locking" setting**. Additive only: the rule can lock, never unlock, and it never writes `_sesamy_locked` meta — rules are evaluated at read time via `has_term()`, so they apply retroactively to the whole archive and removing a term immediately restores whatever the per-post toggle said.

## Changes

- **`is_post_locked()` / `get_post_locking_term()` helpers** (`src/Support/helpers.php`) — single source of truth for the effective lock state, with a `sesamy_is_post_locked` filter as escape hatch. All four consumers now use it: content rendering (including the capsule-sealing gate in `ContentContainer::process_content`), head meta tags (`Meta`), the REST endpoint (`Rest`), and the admin post-list column — so the front end and what the Sesamy server sees always agree.
- **`locked_terms` setting** — "Automatic locking" field on the settings page (general section, after Default Pass): a checkbox list grouped per public taxonomy of the enabled content types. Stored as `{taxonomy, term_id}` objects (REST schema included) so a per-term pass mapping can be added later without a settings migration. The sanitizer accepts both the form encoding (`taxonomy:term_id`) and the canonical REST shape.
- **Gutenberg panel** — the lock toggle shows checked + disabled with "Locked automatically by "⟨term⟩"" when a rule matches, updating live as the editor assigns/removes a locking term (reads the *edited* term selection). Dependent fields (single purchase, paywall URL, redirect) key off the effective state and stay editable.
- **Classic metabox** — same disabled-checkbox + source-note treatment, plus a hidden field that preserves the underlying per-post toggle across saves (disabled inputs don't submit; without this, saving a term-locked post would silently clear a previously-set toggle).
- **Post list** — term-locked posts show `🔒 Locked (Category: X)` under a *distinct* CSS class. This is deliberate: quick-edit populates its checkbox from the `column-sesamy_locked` class, so reusing it would make any quick-edit save round-trip a term lock into post meta.

## Test infrastructure

The repo had tests but no PHPUnit config — `yarn test:php` couldn't run at all. This PR wires it up (`phpunit.xml.dist` + `tests/bootstrap.php` with `WP_Mock::bootstrap()`) and repairs the stale `UrlHelperTest` mocks that surfaced (they predated the connection-bundle helpers).

New coverage: OR semantics, legacy `'0'` meta, filter override, first-match rule selection, malformed-rule handling, sanitizer round-trips (form + REST shapes), and a term-locked render through `process_content` in encode mode.

`vendor/bin/phpunit`: 24 tests / 29 assertions passing · PHPStan: no errors · PHPCS: clean · `yarn build`: succeeds.

## Out of scope (per the issue)

Per-term pass mapping (capsule scope) and a per-post tri-state override — the storage shape and UI slots accommodate both without rework.

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic article locking driven by selected taxonomy terms.
  * Introduced an “Automatic locking” setting to select locking terms.
  * Updated the editor lock toggle and post list “Locked” column to show term-based lock status and lock-source messaging.
* **Bug Fixes**
  * Unified lock-state evaluation across the editor, REST, and frontend, including correct handling of legacy `_sesamy_locked = "0"`.
  * Ensured term-based locking honors the configured lock-mode (e.g., embed vs encode).
* **Documentation**
  * Documented automatic locking behavior, UI expectations, lock combination rules, and cache-flush guidance.
* **Tests**
  * Added PHPUnit coverage for locked-terms parsing and term-based locking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->